### PR TITLE
feat: Implement per-notification cooldowns and suppression (maintenance)

### DIFF
--- a/command/checknow/checknowcommand.go
+++ b/command/checknow/checknowcommand.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/bradselph/CODStatusBot/configuration"
@@ -16,9 +17,9 @@ import (
 )
 
 var (
-	//	rateLimiter     = make(map[string]time.Time)
-	//	rateLimiterLock sync.Mutex
-	rateLimit time.Duration
+	rateLimiter     = make(map[string]time.Time)
+	rateLimiterLock sync.Mutex
+	rateLimit       time.Duration
 )
 
 func init() {

--- a/services/account_manager.go
+++ b/services/account_manager.go
@@ -271,20 +271,15 @@ func handleCheckError(s *discordgo.Session, account *models.Account, err error) 
 	account.ConsecutiveErrors++
 	account.LastErrorTime = time.Now()
 
-	if account.ConsecutiveErrors >= cfg.CaptchaService.MaxRetries {
-		reason := fmt.Sprintf("Max consecutive errors reached (%d). Last error: %v",
-			cfg.CaptchaService.MaxRetries, err)
-		account.IsCheckDisabled = true
-		account.DisabledReason = reason
-		if err := database.DB.Save(account).Error; err != nil {
-			logger.Log.WithError(err).Errorf("Failed to disable account: %s", account.Title)
-		}
-		disableAccount(s, *account, reason)
+	if err := database.DB.Save(account).Error; err != nil {
+		logger.Log.WithError(err).Errorf("Failed to update account error status: %s", account.Title)
 		return
 	}
 
-	if err := database.DB.Save(account).Error; err != nil {
-		logger.Log.WithError(err).Errorf("Failed to update account error status: %s", account.Title)
+	if account.ConsecutiveErrors >= cfg.CaptchaService.MaxRetries {
+		reason := fmt.Sprintf("Max consecutive errors reached (%d). Last error: %v",
+			cfg.CaptchaService.MaxRetries, err)
+		disableAccount(s, *account, reason)
 	}
 }
 

--- a/services/mainfunction.go
+++ b/services/mainfunction.go
@@ -328,6 +328,7 @@ func getStatusFields(account models.Account, status models.Status) []*discordgo.
 func disableAccount(s *discordgo.Session, account models.Account, reason string) {
 	account.IsCheckDisabled = true
 	account.DisabledReason = reason
+	account.ConsecutiveErrors = 0
 
 	if err := database.DB.Save(&account).Error; err != nil {
 		logger.Log.WithError(err).Errorf("Failed to disable account %s", account.Title)
@@ -335,7 +336,6 @@ func disableAccount(s *discordgo.Session, account models.Account, reason string)
 	}
 
 	logger.Log.Infof("Account %s has been disabled. Reason: %s", account.Title, reason)
-
 	NotifyUserAboutDisabledAccount(s, account, reason)
 }
 

--- a/services/mainfunction.go
+++ b/services/mainfunction.go
@@ -26,8 +26,6 @@ var (
 	DBMutex sync.Mutex
 )
 
-//var notificationConfigs map[string]NotificationConfig
-
 func init() {}
 
 func InitializeServices() {

--- a/services/userid.go
+++ b/services/userid.go
@@ -15,17 +15,3 @@ func GetUserID(i *discordgo.InteractionCreate) (string, error) {
 	}
 	return "", fmt.Errorf("unable to determine user ID")
 }
-
-/*
-func GetChannelID(s *discordgo.Session, i *discordgo.InteractionCreate, userID string) (string, error) {
-	if i.ChannelID != "" {
-		return i.ChannelID, nil
-	}
-
-	channel, err := s.UserChannelCreate(userID)
-	if err != nil {
-		return "", fmt.Errorf("failed to create DM channel: %w", err)
-	}
-	return channel.ID, nil
-}
-*/


### PR DESCRIPTION
- Introduces per-notification type cooldowns.
- Adds notification suppression mechanism to store suppressed notifications in the database.
- Updates database schema to include `SuppressedNotification` model.
- Modifies notification limiter to respect per- notification cooldown and maximums.
- Updates daily update notification logic to use user-specified interval or global config.
- Improves notification sending logic and error handling.
- Fixes cookie expiration and error notification logic to send notifications after an interval.
- Disables accounts after consecutive errors exceeding the configured maximum retries.
- Implements a rate limiter for the `/checknow` command.