### PR TITLE
Updates default HTTP client and headers: 1743641982537:update

### DIFF
--- a/services/header.go
+++ b/services/header.go
@@ -7,12 +7,12 @@ import (
 
 func GenerateHeaders(ssoCookie string) map[string]string {
 	headers := map[string]string{
-		"user-agent":         "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.0.0 Safari/537.36",
+		"user-agent":         "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.36",
 		"accept":             "*/*",
 		"accept-language":    "en-US,en;q=0.9",
 		"cache-control":      "no-cache",
 		"pragma":             "no-cache",
-		"sec-ch-ua":          "\"Chromium\";v=\"130\", \"Google Chrome\";v=\"130\", \"Not?A_Brand\";v=\"99\"",
+		"sec-ch-ua":          "\"Chromium\";v=\"134\", \"Google Chrome\";v=\"134\", \"Not?A_Brand\";v=\"99\"",
 		"sec-ch-ua-mobile":   "?0",
 		"sec-ch-ua-platform": "\"Windows\"",
 		"sec-fetch-dest":     "empty",

--- a/services/http_client.go
+++ b/services/http_client.go
@@ -31,17 +31,33 @@ func InitHTTPClients() {
 		TLSHandshakeTimeout: 10 * time.Second,
 	}
 
+	defaultRoundTripper := &defaultHeaderTransport{
+		base: transport,
+	}
+
 	defaultClient = &http.Client{
 		Timeout:   30 * time.Second,
-		Transport: transport,
+		Transport: defaultRoundTripper,
 	}
 
 	longTimeoutClient = &http.Client{
 		Timeout:   60 * time.Second,
-		Transport: transport,
+		Transport: defaultRoundTripper,
 	}
 
 	clientsInitialized = true
+}
+
+type defaultHeaderTransport struct {
+	base http.RoundTripper
+}
+
+func (t *defaultHeaderTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req.Header.Get("User-Agent") == "" {
+		req.Header.Set("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.36")
+	}
+
+	return t.base.RoundTrip(req)
 }
 
 func GetDefaultHTTPClient() *http.Client {


### PR DESCRIPTION
What:
- Introduces a default header transport to inject a user agent if one isn't present in the request.
- Updates default user agent to "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.36".
- Modifies HTTP clients to use the new default header transport.
- Updates the hardcoded user agent string in the `GenerateHeaders` function to match the new default user agent.

Why:
- Ensures all HTTP requests include a user agent to avoid issues with servers that require it.
- Updates the user agent string to a recent version of Chrome to improve compatibility.
- Centralizes user agent management.