### PR TITLE
feat: Implement application-level sharding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ activision code.txt
 admin_api.json
 issues.txt
 Notes-On-features.txt
+/Activision-updates

--- a/bot/bot.go
+++ b/bot/bot.go
@@ -76,14 +76,16 @@ func StartBot() (*discordgo.Session, error) {
 		}
 
 		appShardManager := services.GetAppShardManager()
-		if !appShardManager.Initialized {
-			logger.Log.Debug("App shard manager not initialized, processing interaction")
-		} else {
+		cfg := configuration.Get()
+
+		if cfg.Sharding.Enabled && appShardManager.Initialized && appShardManager.TotalShards > 1 {
 			shouldProcess, reason := shouldProcessInteraction(appShardManager, i)
 			if !shouldProcess {
-				logger.Log.Debugf("Skipping interaction: %s", reason)
+				logger.Log.Debugf("Skipping interaction due to shard assignment: %s", reason)
 				return
 			}
+		} else {
+			logger.Log.Debug("Processing interaction (sharding disabled or failed)")
 		}
 
 		installationType := getInstallationType(i)
@@ -115,10 +117,12 @@ func StartBot() (*discordgo.Session, error) {
 		}
 
 		appShardManager := services.GetAppShardManager()
-		if appShardManager.Initialized {
+		cfg := configuration.Get()
+
+		if cfg.Sharding.Enabled && appShardManager.Initialized && appShardManager.TotalShards > 1 {
 			shouldProcess, reason := shouldProcessMessage(appShardManager, m)
 			if !shouldProcess {
-				logger.Log.Debugf("Skipping message: %s", reason)
+				logger.Log.Debugf("Skipping message due to shard assignment: %s", reason)
 				return
 			}
 		}

--- a/bot/bot.go
+++ b/bot/bot.go
@@ -2,6 +2,7 @@ package bot
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/bradselph/CODStatusBot/command"
@@ -78,28 +79,25 @@ func StartBot() (*discordgo.Session, error) {
 		if !appShardManager.Initialized {
 			logger.Log.Debug("App shard manager not initialized, processing interaction")
 		} else {
-			if i.GuildID != "" {
-				if !appShardManager.GuildBelongsToInstance(i.GuildID) {
-					assignedShard := appShardManager.GetGuildShardID(i.GuildID)
-					logger.Log.Debugf("Skipping interaction in guild %s (assigned to shard %d, this is shard %d)",
-						i.GuildID, assignedShard, appShardManager.ShardID)
-					return
-				}
-			} else {
-				userID := getUserIDFromInteraction(i)
-				if userID != "" {
-					if !appShardManager.ShardBelongsToInstance(userID) {
-						assignedShard := appShardManager.GetUserShardID(userID)
-						logger.Log.Debugf("Skipping direct message interaction from user %s (assigned to shard %d, this is shard %d)",
-							userID, assignedShard, appShardManager.ShardID)
-						return
-					}
-				}
+			shouldProcess, reason := shouldProcessInteraction(appShardManager, i)
+			if !shouldProcess {
+				logger.Log.Debugf("Skipping interaction: %s", reason)
+				return
 			}
 		}
 
 		installationType := getInstallationType(i)
-		logger.Log.Infof("Handling interaction in context: %s", installationType)
+		userID := getUserIDFromInteraction(i)
+
+		logger.Log.Infof("Shard %d processing interaction in context: %s for user: %s",
+			appShardManager.ShardID, installationType, userID)
+
+		services.LogAnalyticsEvent("interaction_received", userID, i.GuildID, "", "",
+			appShardManager.ShardID, appShardManager.InstanceID, map[string]interface{}{
+				"interaction_type":  i.Type.String(),
+				"command_name":      getCommandName(i),
+				"installation_type": installationType,
+			})
 
 		switch i.Type {
 		case discordgo.InteractionApplicationCommand:
@@ -118,30 +116,81 @@ func StartBot() (*discordgo.Session, error) {
 
 		appShardManager := services.GetAppShardManager()
 		if appShardManager.Initialized {
-			if m.GuildID != "" {
-				if !appShardManager.GuildBelongsToInstance(m.GuildID) {
-					assignedShard := appShardManager.GetGuildShardID(m.GuildID)
-					logger.Log.Debugf("Skipping message in guild %s (assigned to shard %d, this is shard %d)",
-						m.GuildID, assignedShard, appShardManager.ShardID)
-					return
-				}
-			} else {
-				if !appShardManager.ShardBelongsToInstance(m.Author.ID) {
-					assignedShard := appShardManager.GetUserShardID(m.Author.ID)
-					logger.Log.Debugf("Skipping direct message from user %s (assigned to shard %d, this is shard %d)",
-						m.Author.ID, assignedShard, appShardManager.ShardID)
-					return
-				}
+			shouldProcess, reason := shouldProcessMessage(appShardManager, m)
+			if !shouldProcess {
+				logger.Log.Debugf("Skipping message: %s", reason)
+				return
 			}
 		}
 
 		channel, err := s.Channel(m.ChannelID)
 		if err == nil && channel.Type == discordgo.ChannelTypeDM {
-			logger.Log.Infof("Received DM from user %s: %s", m.Author.Username, m.Content)
+			logger.Log.Infof("Shard %d received DM from user %s: %s",
+				appShardManager.ShardID, m.Author.Username, m.Content)
 		}
 	})
 
+	discord.AddHandler(func(s *discordgo.Session, r *discordgo.Ready) {
+		appShardManager := services.GetAppShardManager()
+		logger.Log.Infof("Shard %d/%d Discord session ready with %d guilds",
+			appShardManager.ShardID, appShardManager.TotalShards, len(r.Guilds))
+
+		services.LogAnalyticsEvent("shard_ready", "", "", "", "",
+			appShardManager.ShardID, appShardManager.InstanceID, map[string]interface{}{
+				"guild_count": len(r.Guilds),
+				"session_id":  r.SessionID,
+			})
+	})
+
+	discord.AddHandler(func(s *discordgo.Session, d *discordgo.Disconnect) {
+		appShardManager := services.GetAppShardManager()
+		logger.Log.Warnf("Shard %d/%d disconnected from Discord",
+			appShardManager.ShardID, appShardManager.TotalShards)
+
+		services.LogAnalyticsEvent("shard_disconnect", "", "", "", "",
+			appShardManager.ShardID, appShardManager.InstanceID, map[string]interface{}{
+				"disconnect_reason": "discord_disconnect_event",
+			})
+	})
+
 	return discord, nil
+}
+
+func shouldProcessInteraction(shardManager *services.AppShardManager, i *discordgo.InteractionCreate) (bool, string) {
+	if i.GuildID != "" {
+		if !shardManager.GuildBelongsToInstance(i.GuildID) {
+			assignedShard := shardManager.GetGuildShardID(i.GuildID)
+			return false, fmt.Sprintf("guild %s assigned to shard %d, this is shard %d",
+				i.GuildID, assignedShard, shardManager.ShardID)
+		}
+	} else {
+		userID := getUserIDFromInteraction(i)
+		if userID != "" {
+			if !shardManager.ShardBelongsToInstance(userID) {
+				assignedShard := shardManager.GetUserShardID(userID)
+				return false, fmt.Sprintf("user %s assigned to shard %d, this is shard %d",
+					userID, assignedShard, shardManager.ShardID)
+			}
+		}
+	}
+	return true, ""
+}
+
+func shouldProcessMessage(shardManager *services.AppShardManager, m *discordgo.MessageCreate) (bool, string) {
+	if m.GuildID != "" {
+		if !shardManager.GuildBelongsToInstance(m.GuildID) {
+			assignedShard := shardManager.GetGuildShardID(m.GuildID)
+			return false, fmt.Sprintf("guild %s assigned to shard %d, this is shard %d",
+				m.GuildID, assignedShard, shardManager.ShardID)
+		}
+	} else {
+		if !shardManager.ShardBelongsToInstance(m.Author.ID) {
+			assignedShard := shardManager.GetUserShardID(m.Author.ID)
+			return false, fmt.Sprintf("user %s assigned to shard %d, this is shard %d",
+				m.Author.ID, assignedShard, shardManager.ShardID)
+		}
+	}
+	return true, ""
 }
 
 func getInstallationType(i *discordgo.InteractionCreate) string {
@@ -161,11 +210,28 @@ func getUserIDFromInteraction(i *discordgo.InteractionCreate) string {
 	return userID
 }
 
+func getCommandName(i *discordgo.InteractionCreate) string {
+	switch i.Type {
+	case discordgo.InteractionApplicationCommand:
+		return i.ApplicationCommandData().Name
+	case discordgo.InteractionModalSubmit:
+		return i.ModalSubmitData().CustomID
+	case discordgo.InteractionMessageComponent:
+		return i.MessageComponentData().CustomID
+	default:
+		return "unknown"
+	}
+}
+
 func handleModalSubmit(s *discordgo.Session, i *discordgo.InteractionCreate) {
 	defer services.RecoverFromPanic("handleModalSubmit")
 
 	customID := i.ModalSubmitData().CustomID
-	logger.Log.WithField("customID", customID).Debug("Handling modal submit")
+	userID := getUserIDFromInteraction(i)
+	appShardManager := services.GetAppShardManager()
+
+	logger.Log.Debugf("Shard %d handling modal submit %s for user %s",
+		appShardManager.ShardID, customID, userID)
 
 	switch {
 	case strings.HasPrefix(customID, "set_notifications_modal_"):
@@ -197,7 +263,11 @@ func handleMessageComponent(s *discordgo.Session, i *discordgo.InteractionCreate
 	defer services.RecoverFromPanic("handleMessageComponent")
 
 	customID := i.MessageComponentData().CustomID
-	logger.Log.WithField("customID", customID).Debug("Handling message component")
+	userID := getUserIDFromInteraction(i)
+	appShardManager := services.GetAppShardManager()
+
+	logger.Log.Debugf("Shard %d handling message component %s for user %s",
+		appShardManager.ShardID, customID, userID)
 
 	switch {
 	case customID == "listaccounts":

--- a/command/setupcommand.go
+++ b/command/setupcommand.go
@@ -1,6 +1,7 @@
 package command
 
 import (
+	"strings"
 	"time"
 
 	"github.com/bradselph/CODStatusBot/command/accountage"
@@ -18,6 +19,7 @@ import (
 	"github.com/bradselph/CODStatusBot/command/setcheckinterval"
 	"github.com/bradselph/CODStatusBot/command/setephemeral"
 	"github.com/bradselph/CODStatusBot/command/setnotifications"
+	"github.com/bradselph/CODStatusBot/command/shadowbansta
 	"github.com/bradselph/CODStatusBot/command/togglecheck"
 	"github.com/bradselph/CODStatusBot/command/updateaccount"
 	"github.com/bradselph/CODStatusBot/command/verdansk"
@@ -134,6 +136,7 @@ func RegisterCommands(s *discordgo.Session) error {
 			Description:  "Get your Verdansk Replay stats and images",
 			DMPermission: BoolPtr(true),
 		},
+		shadowbanstats.GetShadowbanStatsCommand(),
 	}
 
 	Handlers["set_captcha_service_modal_capsolver"] = setcaptchaservice.HandleModalSubmit
@@ -172,6 +175,7 @@ func RegisterCommands(s *discordgo.Session) error {
 	Handlers["setnotifications"] = setnotifications.CommandSetNotifications
 	Handlers["setephemeral"] = setephemeral.CommandSetEphemeral
 	Handlers["verdansk"] = verdansk.CommandVerdansk
+	Handlers["shadowbanstats"] = shadowbanstats.CommandShadowbanStats
 
 	Handlers["set_notifications_modal"] = setnotifications.HandleModalSubmit
 	Handlers["setcaptchaservice_modal"] = setcaptchaservice.HandleModalSubmit
@@ -185,6 +189,7 @@ func RegisterCommands(s *discordgo.Session) error {
 	Handlers["remove_account"] = removeaccount.HandleAccountSelection
 	Handlers["check_now"] = checknow.HandleAccountSelection
 	Handlers["toggle_check"] = togglecheck.HandleAccountSelection
+	Handlers["update_account"] = updateaccount.HandleAccountSelection
 	Handlers["feedback_anonymous"] = feedback.HandleFeedbackChoice
 	Handlers["feedback_with_id"] = feedback.HandleFeedbackChoice
 	Handlers["set_ephemeral_enable"] = setephemeral.HandleEphemeralSelection
@@ -219,6 +224,13 @@ func HandleCommand(s *discordgo.Session, i *discordgo.InteractionCreate) {
 		commandName = i.ApplicationCommandData().Name
 	} else if i.MessageComponentData().CustomID != "" {
 		commandName = i.MessageComponentData().CustomID
+	}
+
+	if i.Type == discordgo.InteractionApplicationCommandAutocomplete {
+		if commandName == "shadowbanstats" {
+			shadowbanstats.HandleShadowbanStatsAutocomplete(s, i)
+			return
+		}
 	}
 
 	if i.Member != nil {
@@ -265,9 +277,36 @@ func HandleCommand(s *discordgo.Session, i *discordgo.InteractionCreate) {
 	} else if h, ok := Handlers[i.MessageComponentData().CustomID]; ok {
 		h(s, i)
 	} else {
-		logger.Log.Warnf("Unhandled interaction: %s", i.Type)
-		errorDetails = "Unhandled interaction type"
-		success = false
+		customID := i.MessageComponentData().CustomID
+		handled := false
+
+		prefixes := []string{
+			"update_account_",
+			"remove_account_",
+			"check_now_",
+			"toggle_check_",
+			"account_age_",
+			"account_logs_",
+			"verdansk_account_",
+			"update_account_modal_",
+		}
+
+		for _, prefix := range prefixes {
+			if strings.HasPrefix(customID, prefix) {
+				handlerKey := strings.TrimSuffix(prefix, "_")
+				if h, ok := Handlers[handlerKey]; ok {
+					h(s, i)
+					handled = true
+					break
+				}
+			}
+		}
+
+		if !handled {
+			logger.Log.Warnf("Unhandled interaction: %s with customID: %s", i.Type, customID)
+			errorDetails = "Unhandled interaction type"
+			success = false
+		}
 	}
 
 	services.LogCommandExecution(commandName, userID, i.GuildID, success,

--- a/command/shadowbanstats/shadowbanstatscommand.go
+++ b/command/shadowbanstats/shadowbanstatscommand.go
@@ -1,0 +1,261 @@
+package shadowbanstats
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/bradselph/CODStatusBot/database"
+	"github.com/bradselph/CODStatusBot/logger"
+	"github.com/bradselph/CODStatusBot/models"
+	"github.com/bradselph/CODStatusBot/services"
+	"github.com/bradselph/CODStatusBot/utils"
+	"github.com/bwmarrin/discordgo"
+)
+
+func CommandShadowbanStats(s *discordgo.Session, i *discordgo.InteractionCreate) {
+	err := services.DeferWithPreference(s, i, false)
+	if err != nil {
+		logger.Log.WithError(err).Error("Failed to defer response")
+		return
+	}
+
+	userID, err := services.GetUserID(i)
+	if err != nil {
+		logger.Log.WithError(err).Error("Could not determine user ID")
+		sendFollowup(s, i, "An error occurred while processing your request.")
+		return
+	}
+
+	if err := utils.ValidateDiscordUserID(userID); err != nil {
+		logger.Log.WithError(err).WithField("userID", userID).Error("Invalid user ID")
+		sendFollowup(s, i, "Invalid user ID provided.")
+		return
+	}
+
+	var accountCount int64
+	if err := database.DB.Model(&models.Account{}).Where("user_id = ?", userID).Count(&accountCount).Error; err != nil {
+		logger.Log.WithError(err).Error("Error checking user accounts")
+		sendFollowup(s, i, "Error checking your accounts. Please try again.")
+		return
+	}
+
+	if accountCount == 0 {
+		sendFollowup(s, i, "You don't have any monitored accounts. Add an account first using /addaccount.")
+		return
+	}
+
+	days := 30
+	var accountID *uint
+
+	if i.ApplicationCommandData().Options != nil {
+		for _, option := range i.ApplicationCommandData().Options {
+			switch option.Name {
+			case "days":
+				if option.IntValue() > 0 && option.IntValue() <= 365 {
+					days = int(option.IntValue())
+				}
+			case "account":
+				if option.StringValue() != "" {
+					var account models.Account
+					if err := database.DB.Where("user_id = ? AND title = ?", userID, option.StringValue()).First(&account).Error; err == nil {
+						accountID = &account.ID
+					}
+				}
+			}
+		}
+	}
+
+	stats, err := services.GetShadowbanStatistics(userID, accountID, days)
+	if err != nil {
+		logger.Log.WithError(err).Error("Failed to get shadowban statistics")
+		sendFollowup(s, i, "Failed to retrieve shadowban statistics. Please try again.")
+		return
+	}
+
+	embed := createShadowbanStatsEmbed(stats, accountID != nil)
+
+	_, err = services.FollowupWithPreference(s, i, "", []*discordgo.MessageEmbed{embed}, nil, false)
+	if err != nil {
+		logger.Log.WithError(err).Error("Error sending followup message")
+	}
+}
+
+func createShadowbanStatsEmbed(stats map[string]interface{}, isAccountSpecific bool) *discordgo.MessageEmbed {
+	title := "Your Shadowban Statistics"
+	if isAccountSpecific {
+		title = "Account Shadowban Statistics"
+	}
+
+	days := stats["period_days"].(int)
+	startDate := stats["start_date"].(string)
+	endDate := stats["end_date"].(string)
+
+	description := fmt.Sprintf("**Period:** %s to %s (%d days)\n", startDate, endDate, days)
+
+	embed := &discordgo.MessageEmbed{
+		Title:       title,
+		Description: description,
+		Color:       0x3498db,
+		Timestamp:   time.Now().Format(time.RFC3339),
+		Fields:      make([]*discordgo.MessageEmbedField, 0),
+	}
+
+	completedPeriods := stats["total_completed_periods"].(int)
+	activePeriods := stats["active_periods"].(int64)
+
+	embed.Fields = append(embed.Fields, &discordgo.MessageEmbedField{
+		Name:   "Overview",
+		Value:  fmt.Sprintf("Completed Shadowbans: **%d**\nCurrently Active: **%d**", completedPeriods, activePeriods),
+		Inline: false,
+	})
+
+	if completedPeriods > 0 {
+		if avgHours, ok := stats["average_duration_hours"].(float64); ok {
+			avgDays := stats["average_duration_days"].(float64)
+			minHours := stats["min_duration_hours"].(float64)
+			maxHours := stats["max_duration_hours"].(float64)
+			totalHours := stats["total_shadowban_hours"].(float64)
+
+			embed.Fields = append(embed.Fields, &discordgo.MessageEmbedField{
+				Name: "Duration Analysis",
+				Value: fmt.Sprintf("Average: **%.1f hours** (%.1f days)\nShortest: **%.1f hours** (%.1f days)\nLongest: **%.1f hours** (%.1f days)\nTotal Time: **%.1f hours** (%.1f days)",
+					avgHours, avgDays,
+					minHours, minHours/24,
+					maxHours, maxHours/24,
+					totalHours, totalHours/24),
+				Inline: false,
+			})
+		}
+
+		if recentPeriods, ok := stats["recent_periods"].([]map[string]interface{}); ok && len(recentPeriods) > 0 {
+			recentValue := ""
+			maxShow := 5
+			if len(recentPeriods) < maxShow {
+				maxShow = len(recentPeriods)
+			}
+
+			for i := 0; i < maxShow; i++ {
+				period := recentPeriods[i]
+				accountTitle := period["account_title"].(string)
+				startTime := period["start_time"].(string)
+				endTime := period["end_time"].(string)
+
+				if durationHours, ok := period["duration_hours"].(float64); ok {
+					durationDays := period["duration_days"].(float64)
+					recentValue += fmt.Sprintf("**%s**\n%s → %s\nDuration: %.1f hours (%.1f days)\n\n",
+						accountTitle,
+						formatTimeShort(startTime),
+						formatTimeShort(endTime),
+						durationHours, durationDays)
+				}
+			}
+
+			if len(recentValue) > 0 {
+				if len(recentPeriods) > maxShow {
+					recentValue += fmt.Sprintf("*...and %d more*", len(recentPeriods)-maxShow)
+				}
+
+				embed.Fields = append(embed.Fields, &discordgo.MessageEmbedField{
+					Name:   fmt.Sprintf("Recent Shadowbans (%d shown)", maxShow),
+					Value:  recentValue,
+					Inline: false,
+				})
+			}
+		}
+	} else {
+		embed.Fields = append(embed.Fields, &discordgo.MessageEmbedField{
+			Name:   "No Data",
+			Value:  fmt.Sprintf("No completed shadowban periods found in the last %d days.\n\nThis could mean:\n• No shadowbans occurred\n• Shadowbans started before tracking began\n• Account status was 'Unknown' when shadowbans started", days),
+			Inline: false,
+		})
+	}
+
+	if activePeriods > 0 {
+		embed.Fields = append(embed.Fields, &discordgo.MessageEmbedField{
+			Name:   "Active Shadowbans",
+			Value:  fmt.Sprintf("You currently have **%d** account(s) under review. Duration tracking will complete when the status changes to 'Good'.", activePeriods),
+			Inline: false,
+		})
+	}
+
+	embed.Footer = &discordgo.MessageEmbedFooter{
+		Text: "Note: Only shadowbans with reliable start/end times are included in duration calculations",
+	}
+
+	return embed
+}
+
+func formatTimeShort(timeStr string) string {
+	t, err := time.Parse("2006-01-02 15:04:05", timeStr)
+	if err != nil {
+		return timeStr
+	}
+	return t.Format("Jan 02 15:04")
+}
+
+func sendFollowup(s *discordgo.Session, i *discordgo.InteractionCreate, content string) {
+	_, err := services.FollowupWithPreference(s, i, content, nil, nil, false)
+	if err != nil {
+		logger.Log.WithError(err).Error("Error sending followup message")
+	}
+}
+
+func GetShadowbanStatsCommand() *discordgo.ApplicationCommand {
+	return &discordgo.ApplicationCommand{
+		Name:        "shadowbanstats",
+		Description: "View shadowban duration statistics for your accounts",
+		Options: []*discordgo.ApplicationCommandOption{
+			{
+				Type:        discordgo.ApplicationCommandOptionInteger,
+				Name:        "days",
+				Description: "Number of days to look back (1-365, default: 30)",
+				Required:    false,
+				MinValue:    func() *float64 { v := 1.0; return &v }(),
+				MaxValue:    365,
+			},
+			{
+				Type:         discordgo.ApplicationCommandOptionString,
+				Name:         "account",
+				Description:  "Show stats for a specific account (leave blank for all accounts)",
+				Required:     false,
+				Autocomplete: true,
+			},
+		},
+	}
+}
+
+func HandleShadowbanStatsAutocomplete(s *discordgo.Session, i *discordgo.InteractionCreate) {
+	userID, err := services.GetUserID(i)
+	if err != nil {
+		logger.Log.WithError(err).Error("Could not determine user ID for autocomplete")
+		return
+	}
+
+	var accounts []models.Account
+	if err := database.DB.Where("user_id = ?", userID).Select("title").Find(&accounts).Error; err != nil {
+		logger.Log.WithError(err).Error("Failed to fetch accounts for autocomplete")
+		return
+	}
+
+	var choices []*discordgo.ApplicationCommandOptionChoice
+	for _, account := range accounts {
+		if len(choices) >= 25 {
+			break
+		}
+		choices = append(choices, &discordgo.ApplicationCommandOptionChoice{
+			Name:  account.Title,
+			Value: account.Title,
+		})
+	}
+
+	err = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+		Type: discordgo.InteractionApplicationCommandAutocompleteResult,
+		Data: &discordgo.InteractionResponseData{
+			Choices: choices,
+		},
+	})
+
+	if err != nil {
+		logger.Log.WithError(err).Error("Failed to respond to autocomplete")
+	}
+}

--- a/command/updateaccount/updateaccountcommand.go
+++ b/command/updateaccount/updateaccountcommand.go
@@ -46,10 +46,7 @@ func CommandUpdateAccount(s *discordgo.Session, i *discordgo.InteractionCreate) 
 		return
 	}
 
-	var (
-		components []discordgo.MessageComponent
-		currentRow []discordgo.MessageComponent
-	)
+	var components []discordgo.MessageComponent
 
 	for _, account := range accounts {
 		label := account.Title
@@ -59,30 +56,14 @@ func CommandUpdateAccount(s *discordgo.Session, i *discordgo.InteractionCreate) 
 
 		if account.IsCheckDisabled {
 			label += " (Disabled)"
-			button := discordgo.Button{
-				Label:    label,
-				Style:    discordgo.SecondaryButton,
-				CustomID: fmt.Sprintf("update_account_%d", account.ID),
-			}
-			currentRow = append(currentRow, button)
+			button := services.CreateV2Button(label, fmt.Sprintf("update_account_%d", account.ID), discordgo.SecondaryButton)
+			components = append(components, button)
 		} else {
-			button := discordgo.Button{
-				Label:    label,
-				Style:    discordgo.PrimaryButton,
-				CustomID: fmt.Sprintf("update_account_%d", account.ID),
-			}
-			currentRow = append(currentRow, button)
-		}
-
-		if len(currentRow) == 5 {
-			components = append(components, discordgo.ActionsRow{Components: currentRow})
-			currentRow = []discordgo.MessageComponent{}
+			button := services.CreateV2Button(label, fmt.Sprintf("update_account_%d", account.ID), discordgo.PrimaryButton)
+			components = append(components, button)
 		}
 	}
 
-	if len(currentRow) > 0 {
-		components = append(components, discordgo.ActionsRow{Components: currentRow})
-	}
 	_, err = services.FollowupWithPreference(s, i, "Select an account to update:", nil, components, false)
 	if err != nil {
 		logger.Log.WithError(err).Error("Error sending followup with account selection")

--- a/configuration/global-config.go
+++ b/configuration/global-config.go
@@ -603,16 +603,22 @@ func loadShardingConfig() {
 
 	if AppConfig.Sharding.Enabled {
 		if AppConfig.Sharding.TotalShards < 1 {
-			logger.Log.Warn("Invalid TOTAL_SHARDS value, must be at least 1. Setting to 1.")
+			logger.Log.Warn("Invalid TOTAL_SHARDS value, disabling sharding")
+			AppConfig.Sharding.Enabled = false
 			AppConfig.Sharding.TotalShards = 1
-		}
-
-		if AppConfig.Sharding.ShardID < 0 || AppConfig.Sharding.ShardID >= AppConfig.Sharding.TotalShards {
-			logger.Log.Warnf("Invalid SHARD_ID %d for TOTAL_SHARDS %d. Setting to 0.",
-				AppConfig.Sharding.ShardID, AppConfig.Sharding.TotalShards)
 			AppConfig.Sharding.ShardID = 0
 		}
 
+		if AppConfig.Sharding.ShardID < 0 || AppConfig.Sharding.ShardID >= AppConfig.Sharding.TotalShards {
+			logger.Log.Warnf("Invalid SHARD_ID %d for TOTAL_SHARDS %d, disabling sharding",
+				AppConfig.Sharding.ShardID, AppConfig.Sharding.TotalShards)
+			AppConfig.Sharding.Enabled = false
+			AppConfig.Sharding.TotalShards = 1
+			AppConfig.Sharding.ShardID = 0
+		}
+	}
+
+	if AppConfig.Sharding.Enabled {
 		logger.Log.Infof("Sharding enabled: This is shard %d of %d",
 			AppConfig.Sharding.ShardID, AppConfig.Sharding.TotalShards)
 	} else {

--- a/database/database.go
+++ b/database/database.go
@@ -144,6 +144,9 @@ func RunMigrations() {
 		if err := DB.Exec("ALTER TABLE analytics ADD COLUMN shard_id INT DEFAULT 0").Error; err != nil {
 			logger.Log.WithError(err).Error("Failed to add shard_id column to Analytics table")
 		}
+		if err := DB.Exec("CREATE INDEX idx_analytics_shard_id ON analytics (shard_id)").Error; err != nil {
+			logger.Log.WithError(err).Error("Failed to create shard_id index on Analytics table")
+		}
 	}
 
 	if !DB.Migrator().HasColumn(&models.Analytics{}, "instance_id") {
@@ -151,8 +154,36 @@ func RunMigrations() {
 		if err := DB.Exec("ALTER TABLE analytics ADD COLUMN instance_id VARCHAR(255) DEFAULT ''").Error; err != nil {
 			logger.Log.WithError(err).Error("Failed to add instance_id column to Analytics table")
 		}
+		if err := DB.Exec("CREATE INDEX idx_analytics_instance_id ON analytics (instance_id)").Error; err != nil {
+			logger.Log.WithError(err).Error("Failed to create instance_id index on Analytics table")
+		}
 	}
 
+	if !DB.Migrator().HasColumn(&models.ShardInfo{}, "startup_time") {
+		logger.Log.Info("Adding startup_time column to ShardInfo table")
+		if err := DB.Exec("ALTER TABLE shard_infos ADD COLUMN startup_time datetime(3)").Error; err != nil {
+			logger.Log.WithError(err).Error("Failed to add startup_time column to ShardInfo table")
+		}
+	}
+
+	if !DB.Migrator().HasColumn(&models.ShardInfo{}, "process_id") {
+		logger.Log.Info("Adding process_id column to ShardInfo table")
+		if err := DB.Exec("ALTER TABLE shard_infos ADD COLUMN process_id bigint").Error; err != nil {
+			logger.Log.WithError(err).Error("Failed to add process_id column to ShardInfo table")
+		}
+	}
+
+	if !DB.Migrator().HasColumn(&models.ShardInfo{}, "hostname") {
+		logger.Log.Info("Adding hostname column to ShardInfo table")
+		if err := DB.Exec("ALTER TABLE shard_infos ADD COLUMN hostname varchar(255)").Error; err != nil {
+			logger.Log.WithError(err).Error("Failed to add hostname column to ShardInfo table")
+		}
+		if err := DB.Exec("CREATE INDEX idx_shard_infos_hostname ON shard_infos (hostname)").Error; err != nil {
+			logger.Log.WithError(err).Error("Failed to create hostname index on ShardInfo table")
+		}
+	}
+
+	// Continue with existing migrations...
 	if !DB.Migrator().HasColumn(&models.Account{}, "game_specific_bans") {
 		logger.Log.Info("Adding game_specific_bans column to Account table")
 		if err := DB.Exec("ALTER TABLE accounts ADD COLUMN game_specific_bans JSON").Error; err != nil {

--- a/database/database.go
+++ b/database/database.go
@@ -137,6 +137,10 @@ func CleanupInvalidTimestamps() {
 func RunMigrations() {
 	logger.Log.Info("Running migrations")
 
+	if err := createShadowbanPeriodsTable(); err != nil {
+		logger.Log.WithError(err).Error("Failed to create shadowban_periods table")
+	}
+
 	CleanupInvalidTimestamps()
 
 	if !DB.Migrator().HasColumn(&models.Analytics{}, "shard_id") {
@@ -280,7 +284,6 @@ func RunMigrations() {
 		}
 	}
 
-	// Initialize JSON fields
 	if err := DB.Exec("UPDATE accounts SET game_specific_bans = '{}' WHERE game_specific_bans IS NULL OR game_specific_bans = ''").Error; err != nil {
 		logger.Log.WithError(err).Error("Failed to initialize game_specific_bans")
 	}
@@ -407,4 +410,36 @@ func MigrateFallbackDefaults() {
 			logger.Log.Infof("Successfully migrated %d users to default fallback setting", result.RowsAffected)
 		}
 	}
+}
+
+func createShadowbanPeriodsTable() error {
+	sql := `
+	CREATE TABLE IF NOT EXISTS shadowban_periods (
+		id BIGINT AUTO_INCREMENT PRIMARY KEY,
+		account_id BIGINT NOT NULL,
+		user_id VARCHAR(255) NOT NULL,
+		account_title VARCHAR(255) NOT NULL,
+		start_time DATETIME(3) NOT NULL,
+		end_time DATETIME(3) NULL,
+		duration_hours DOUBLE NULL,
+		is_completed BOOLEAN NOT NULL DEFAULT FALSE,
+		start_ban_id BIGINT NOT NULL,
+		end_ban_id BIGINT NULL,
+		created_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+		updated_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
+		INDEX idx_account_id (account_id),
+		INDEX idx_user_id (user_id),
+		INDEX idx_created_at (created_at),
+		INDEX idx_is_completed (is_completed),
+		INDEX idx_start_time (start_time),
+		INDEX idx_end_time (end_time)
+	) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci`
+
+	if err := DB.Exec(sql).Error; err != nil {
+		logger.Log.WithError(err).Error("Failed to create shadowban_periods table")
+		return err
+	}
+
+	logger.Log.Info("Successfully created or verified shadowban_periods table")
+	return nil
 }

--- a/main.go
+++ b/main.go
@@ -149,18 +149,22 @@ func run() error {
 
 	appShardManager := services.GetAppShardManager()
 	if err := appShardManager.Initialize(); err != nil {
-		logger.Log.WithError(err).Error("Failed to initialize app shard manager")
+		return fmt.Errorf("failed to initialize app shard manager: %w", err)
 	}
 
 	shardCtx, shardCancel := context.WithCancel(context.Background())
 	defer shardCancel()
 
 	appShardManager.StartHeartbeat(shardCtx)
-	logger.Log.Infof("Application shard %d of %d initialized successfully",
-		appShardManager.ShardID, appShardManager.TotalShards)
+	logger.Log.Infof("Application shard %d of %d initialized successfully (Instance: %s)",
+		appShardManager.ShardID, appShardManager.TotalShards, appShardManager.InstanceID)
 
-	services.StartAdminAPI()
-	logger.Log.Info("Admin API started successfully")
+	if appShardManager.IsLeader() {
+		services.StartAdminAPI()
+		logger.Log.Info("Started Admin API (leader shard)")
+	} else {
+		logger.Log.Info("Skipping Admin API startup (not leader shard)")
+	}
 
 	var err error
 	discord, err = bot.StartBot()
@@ -176,19 +180,28 @@ func run() error {
 	defer cancel()
 
 	periodicTasksCtx, cancelPeriodicTasks := context.WithCancel(ctx)
-	go startPeriodicTasks(periodicTasksCtx, discord)
+	go startPeriodicTasks(periodicTasksCtx, discord, appShardManager)
 
 	errorCleanupCtx, cancelErrorCleanup := context.WithCancel(ctx)
-	go services.StartErrorCleanupRoutine(errorCleanupCtx)
+	if appShardManager.IsLeader() {
+		go services.StartErrorCleanupRoutine(errorCleanupCtx)
+		logger.Log.Info("Started error cleanup routine (leader shard)")
+	}
 
 	edgeCaseCtx, cancelEdgeCase := context.WithCancel(ctx)
-	go services.StartEdgeCaseCleanupRoutine(edgeCaseCtx)
+	if appShardManager.IsLeader() {
+		go services.StartEdgeCaseCleanupRoutine(edgeCaseCtx)
+		logger.Log.Info("Started edge case cleanup routine (leader shard)")
+	}
 
-	verdansk.InitCleanupRoutine()
+	if appShardManager.IsLeader() {
+		verdansk.InitCleanupRoutine()
+		logger.Log.Info("Initialized Verdansk cleanup routine (leader shard)")
+	}
 
 	logger.Log.Info("COD Status Bot startup complete")
 
-	go startHealthCheckRoutine(discord)
+	go startHealthCheckRoutine(discord, appShardManager)
 
 	stop := make(chan os.Signal, 1)
 	signal.Notify(stop, os.Interrupt, syscall.SIGTERM)
@@ -206,6 +219,12 @@ func run() error {
 		logger.Log.Warn("Startup timeout reached, continuing anyway")
 	}
 
+	services.LogAnalyticsEvent("shard_startup_complete", "", "", "", "",
+		appShardManager.ShardID, appShardManager.InstanceID, map[string]interface{}{
+			"is_leader":                appShardManager.IsLeader(),
+			"startup_duration_seconds": 5,
+		})
+
 	<-stop
 
 	logger.Log.Info("Shutting down COD Status Bot...")
@@ -218,6 +237,7 @@ func run() error {
 	defer shutdownCancel()
 	done := make(chan struct{})
 	go func() {
+		services.HandleGracefulShutdown(discord)
 		close(done)
 	}()
 
@@ -228,173 +248,183 @@ func run() error {
 		logger.Log.Warn("Shutdown timed out, forcing exit")
 	}
 
-	services.HandleGracefulShutdown(discord)
+	services.LogAnalyticsEvent("shard_shutdown", "", "", "", "",
+		appShardManager.ShardID, appShardManager.InstanceID, map[string]interface{}{
+			"shutdown_reason": "signal_received",
+		})
 
 	logger.Log.Info("Shutdown complete")
 	return nil
 }
 
-func startPeriodicTasks(ctx context.Context, s *discordgo.Session) {
+func startPeriodicTasks(ctx context.Context, s *discordgo.Session, shardManager *services.AppShardManager) {
 	cfg := configuration.Get()
+
 	go func() {
+		checkTicker := time.NewTicker(time.Duration(cfg.Intervals.Sleep) * time.Minute)
+		defer checkTicker.Stop()
+
 		for {
 			select {
 			case <-ctx.Done():
 				return
-			default:
-				services.CheckAccounts(s)
-				time.Sleep(time.Duration(cfg.Intervals.Sleep) * time.Minute)
+			case <-checkTicker.C:
+				if shardManager.Initialized {
+					logger.Log.Debugf("Shard %d starting account check cycle", shardManager.ShardID)
+					services.CheckAccounts(s)
+				}
 			}
 		}
 	}()
-	go func() {
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			default:
-				var users []models.UserSettings
-				if err := database.DB.Find(&users).Error; err != nil {
-					logger.Log.WithError(err).Error("Failed to fetch users for consolidated updates")
-					time.Sleep(time.Hour)
-					continue
-				}
 
-				for _, user := range users {
-					var accounts []models.Account
-					if err := database.DB.Where("user_id = ? AND is_check_disabled = ? AND is_expired_cookie = ?",
-						user.UserID, false, false).Find(&accounts).Error; err != nil {
-						logger.Log.WithError(err).Error("Failed to fetch accounts for user")
+	if shardManager.IsLeader() {
+		go func() {
+			updateTicker := time.NewTicker(time.Hour)
+			defer updateTicker.Stop()
+
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case <-updateTicker.C:
+					logger.Log.Debug("Leader shard processing consolidated daily updates")
+					var users []models.UserSettings
+					if err := database.DB.Find(&users).Error; err != nil {
+						logger.Log.WithError(err).Error("Failed to fetch users for consolidated updates")
 						continue
 					}
+					for _, user := range users {
+						if !shardManager.IsUserAssignedToShard(user.UserID) {
 
-					if time.Since(user.LastDailyUpdateNotification) >=
-						time.Duration(cfg.Intervals.Notification)*time.Hour {
-						services.SendConsolidatedDailyUpdate(s, user.UserID, user, accounts)
+							processedUsers := 0
+							continue
+						}
+
+						var accounts []models.Account
+						if err := database.DB.Where("user_id = ? AND is_check_disabled = ? AND is_expired_cookie = ?",
+							user.UserID, false, false).Find(&accounts).Error; err != nil {
+							logger.Log.WithError(err).Error("Failed to fetch accounts for user")
+							continue
+						}
+
+						if time.Since(user.LastDailyUpdateNotification) >=
+							time.Duration(cfg.Intervals.Notification)*time.Hour {
+							services.SendConsolidatedDailyUpdate(s, user.UserID, user, accounts)
+							processedUsers++
+						}
+					}
+					logger.Log.Debugf("Leader shard processed %d users for daily updates", processedUsers)
+				}
+			}
+		}()
+
+		go services.ScheduleBalanceChecks(s)
+
+		go func() {
+			announcementTicker := time.NewTicker(24 * time.Hour)
+			defer announcementTicker.Stop()
+
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case <-announcementTicker.C:
+					if err := services.SendAnnouncementToAllUsers(s); err != nil {
+						logger.Log.WithError(err).Error("Failed to send global announcement")
 					}
 				}
-
-				time.Sleep(time.Hour)
 			}
-		}
-	}()
+		}()
 
-	go services.ScheduleBalanceChecks(s)
+		go func() {
+			cleanupTicker := time.NewTicker(12 * time.Hour)
+			defer cleanupTicker.Stop()
 
-	go func() {
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			default:
-				if err := services.SendAnnouncementToAllUsers(s); err != nil {
-					logger.Log.WithError(err).Error("Failed to send global announcement")
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case <-cleanupTicker.C:
+					services.CleanupOldRateLimitData()
+					logger.Log.Debug("Leader shard completed rate limit cleanup")
 				}
-				time.Sleep(24 * time.Hour)
 			}
-		}
-	}()
+		}()
+
+		go func() {
+			userCleanupTicker := time.NewTicker(cfg.Users.CleanupInterval)
+			defer userCleanupTicker.Stop()
+
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case <-userCleanupTicker.C:
+					services.CleanupInactiveUsers()
+					logger.Log.Info("Leader shard completed inactive users cleanup")
+					services.LogInstallationStats(s)
+				}
+			}
+		}()
+
+		go func() {
+			analyticsTicker := time.NewTicker(24 * time.Hour)
+			defer analyticsTicker.Stop()
+
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case <-analyticsTicker.C:
+					if err := services.CleanupOldAnalyticsData(cfg.Admin.RetentionDays); err != nil {
+						logger.Log.WithError(err).Error("Failed to clean up old analytics data")
+					}
+				}
+			}
+		}()
+	}
 
 	go func() {
+		statusTicker := time.NewTicker(60 * time.Minute)
+		defer statusTicker.Stop()
+
 		for {
 			select {
 			case <-ctx.Done():
 				return
-			default:
+			case <-statusTicker.C:
 				if err := s.UpdateWatchStatus(0, bot.StatusMessage); err != nil {
 					logger.Log.WithError(err).Error("Failed to refresh presence status")
 				}
-				time.Sleep(60 * time.Minute)
 			}
 		}
 	}()
 
-	go func() {
-		ticker := time.NewTicker(12 * time.Hour)
-		defer ticker.Stop()
-
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case <-ticker.C:
-				services.CleanupOldRateLimitData()
-			}
-		}
-	}()
-
-	go func() {
-		ticker := time.NewTicker(cfg.Users.CleanupInterval)
-		defer ticker.Stop()
-
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case <-ticker.C:
-				services.CleanupInactiveUsers()
-				logger.Log.Info("Ran inactive users cleanup")
-				services.LogInstallationStats(s)
-			}
-		}
-	}()
-
-	go func() {
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			default:
-				if err := s.UpdateWatchStatus(0, bot.StatusMessage); err != nil {
-					logger.Log.WithError(err).Error("Failed to refresh presence status")
-				}
-				time.Sleep(60 * time.Minute)
-			}
-		}
-	}()
-
-	go func() {
-		ticker := time.NewTicker(24 * time.Hour)
-		defer ticker.Stop()
-
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case <-ticker.C:
-				cfg := configuration.Get()
-				if err := services.CleanupOldAnalyticsData(cfg.Admin.RetentionDays); err != nil {
-					logger.Log.WithError(err).Error("Failed to clean up old analytics data")
-				}
-			}
-		}
-	}()
-
-	logger.Log.Info("Periodic tasks started successfully")
+	logger.Log.Infof("Shard %d periodic tasks started (leader: %v)",
+		shardManager.ShardID, shardManager.IsLeader())
 }
 
-func startHealthCheckRoutine(s *discordgo.Session) {
+func startHealthCheckRoutine(s *discordgo.Session, shardManager *services.AppShardManager) {
 	cfg := configuration.Get()
 	ticker := time.NewTicker(cfg.Startup.HealthCheckInterval)
 	defer ticker.Stop()
 
 	for range ticker.C {
 		if s.DataReady == false {
-			logger.Log.Error("Discord connection is not ready")
+			logger.Log.Errorf("Shard %d Discord connection is not ready", shardManager.ShardID)
 			continue
 		}
 
 		if err := database.CheckConnection(); err != nil {
-			logger.Log.WithError(err).Error("Database health check failed")
+			logger.Log.WithError(err).Errorf("Shard %d database health check failed", shardManager.ShardID)
 			continue
 		}
 
-		shardMgr := services.GetAppShardManager()
-		if !shardMgr.Initialized {
-			logger.Log.Error("Shard manager is not initialized")
+		if !shardManager.Initialized {
+			logger.Log.Errorf("Shard %d manager is not initialized", shardManager.ShardID)
 			continue
 		}
 
-		logger.Log.Debug("Health check passed")
+		logger.Log.Debugf("Shard %d health check passed", shardManager.ShardID)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -148,9 +148,7 @@ func run() error {
 	logger.Log.Info("Proxy stats initialization completed")
 
 	appShardManager := services.GetAppShardManager()
-	if err := appShardManager.Initialize(); err != nil {
-		return fmt.Errorf("failed to initialize app shard manager: %w", err)
-	}
+	appShardManager.EnsureInitialized()
 
 	shardCtx, shardCancel := context.WithCancel(context.Background())
 	defer shardCancel()
@@ -159,9 +157,10 @@ func run() error {
 	logger.Log.Infof("Application shard %d of %d initialized successfully (Instance: %s)",
 		appShardManager.ShardID, appShardManager.TotalShards, appShardManager.InstanceID)
 
-	if appShardManager.IsLeader() {
+	cfg = configuration.Get()
+	if !cfg.Sharding.Enabled || appShardManager.IsLeader() {
 		services.StartAdminAPI()
-		logger.Log.Info("Started Admin API (leader shard)")
+		logger.Log.Info("Started Admin API")
 	} else {
 		logger.Log.Info("Skipping Admin API startup (not leader shard)")
 	}
@@ -183,20 +182,20 @@ func run() error {
 	go startPeriodicTasks(periodicTasksCtx, discord, appShardManager)
 
 	errorCleanupCtx, cancelErrorCleanup := context.WithCancel(ctx)
-	if appShardManager.IsLeader() {
+	if !cfg.Sharding.Enabled || appShardManager.IsLeader() {
 		go services.StartErrorCleanupRoutine(errorCleanupCtx)
-		logger.Log.Info("Started error cleanup routine (leader shard)")
+		logger.Log.Info("Started error cleanup routine")
 	}
 
 	edgeCaseCtx, cancelEdgeCase := context.WithCancel(ctx)
-	if appShardManager.IsLeader() {
+	if !cfg.Sharding.Enabled || appShardManager.IsLeader() {
 		go services.StartEdgeCaseCleanupRoutine(edgeCaseCtx)
-		logger.Log.Info("Started edge case cleanup routine (leader shard)")
+		logger.Log.Info("Started edge case cleanup routine")
 	}
 
-	if appShardManager.IsLeader() {
+	if !cfg.Sharding.Enabled || appShardManager.IsLeader() {
 		verdansk.InitCleanupRoutine()
-		logger.Log.Info("Initialized Verdansk cleanup routine (leader shard)")
+		logger.Log.Info("Initialized Verdansk cleanup routine")
 	}
 
 	logger.Log.Info("COD Status Bot startup complete")
@@ -277,7 +276,7 @@ func startPeriodicTasks(ctx context.Context, s *discordgo.Session, shardManager 
 		}
 	}()
 
-	if shardManager.IsLeader() {
+	if !cfg.Sharding.Enabled || shardManager.IsLeader() {
 		go func() {
 			updateTicker := time.NewTicker(time.Hour)
 			defer updateTicker.Stop()
@@ -287,7 +286,7 @@ func startPeriodicTasks(ctx context.Context, s *discordgo.Session, shardManager 
 				case <-ctx.Done():
 					return
 				case <-updateTicker.C:
-					logger.Log.Debug("Leader shard processing consolidated daily updates")
+					logger.Log.Debug("Processing consolidated daily updates")
 
 					var allUsers []models.UserSettings
 					if err := database.DB.Find(&allUsers).Error; err != nil {
@@ -296,7 +295,11 @@ func startPeriodicTasks(ctx context.Context, s *discordgo.Session, shardManager 
 					}
 
 					users := services.FilterUserSettingsByShardAssignment(allUsers)
-					logger.Log.Debugf("Processing daily updates for %d users assigned to this shard (filtered from %d total)", len(users), len(allUsers))
+					if cfg.Sharding.Enabled && shardManager.TotalShards > 1 {
+						logger.Log.Debugf("Processing daily updates for %d users assigned to this shard (filtered from %d total)", len(users), len(allUsers))
+					} else {
+						logger.Log.Debugf("Processing daily updates for %d users (sharding disabled)", len(users))
+					}
 
 					processedUsers := 0
 					for _, user := range users {
@@ -304,9 +307,11 @@ func startPeriodicTasks(ctx context.Context, s *discordgo.Session, shardManager 
 							continue
 						}
 
-						if !shardManager.IsUserAssignedToShard(user.UserID) {
-							logger.Log.Debugf("User %s no longer assigned to this shard, skipping", user.UserID)
-							continue
+						if cfg.Sharding.Enabled && shardManager.TotalShards > 1 {
+							if !shardManager.IsUserAssignedToShard(user.UserID) {
+								logger.Log.Debugf("User %s no longer assigned to this shard, skipping", user.UserID)
+								continue
+							}
 						}
 
 						var accounts []models.Account
@@ -322,7 +327,7 @@ func startPeriodicTasks(ctx context.Context, s *discordgo.Session, shardManager 
 							processedUsers++
 						}
 					}
-					logger.Log.Debugf("Leader shard processed %d users for daily updates", processedUsers)
+					logger.Log.Debugf("Processed %d users for daily updates", processedUsers)
 				}
 			}
 		}()
@@ -355,7 +360,7 @@ func startPeriodicTasks(ctx context.Context, s *discordgo.Session, shardManager 
 					return
 				case <-cleanupTicker.C:
 					services.CleanupOldRateLimitData()
-					logger.Log.Debug("Leader shard completed rate limit cleanup")
+					logger.Log.Debug("Completed rate limit cleanup")
 				}
 			}
 		}()
@@ -369,7 +374,7 @@ func startPeriodicTasks(ctx context.Context, s *discordgo.Session, shardManager 
 				case <-ctx.Done():
 					return
 				case <-userCleanupTicker.C:
-					logger.Log.Info("Leader shard starting comprehensive cleanup")
+					logger.Log.Info("Starting comprehensive cleanup")
 
 					services.CleanupInactiveUsers()
 					logger.Log.Info("Completed inactive users cleanup")
@@ -381,7 +386,7 @@ func startPeriodicTasks(ctx context.Context, s *discordgo.Session, shardManager 
 					logger.Log.Info("Completed shard info cleanup")
 
 					services.LogInstallationStats(s)
-					logger.Log.Info("Leader shard completed comprehensive cleanup")
+					logger.Log.Info("Completed comprehensive cleanup")
 				}
 			}
 		}()
@@ -395,7 +400,7 @@ func startPeriodicTasks(ctx context.Context, s *discordgo.Session, shardManager 
 				case <-ctx.Done():
 					return
 				case <-analyticsTicker.C:
-					logger.Log.Info("Leader shard starting analytics cleanup")
+					logger.Log.Info("Starting analytics cleanup")
 					if err := services.CleanupOldAnalyticsData(cfg.Admin.RetentionDays); err != nil {
 						logger.Log.WithError(err).Error("Failed to clean up old analytics data")
 					} else {
@@ -429,8 +434,11 @@ func startPeriodicTasks(ctx context.Context, s *discordgo.Session, shardManager 
 		}
 	}()
 
-	logger.Log.Infof("Shard %d periodic tasks started (leader: %v)",
-		shardManager.ShardID, shardManager.IsLeader())
+	if cfg.Sharding.Enabled {
+		logger.Log.Infof("Shard %d periodic tasks started (leader: %v)", shardManager.ShardID, shardManager.IsLeader())
+	} else {
+		logger.Log.Info("Periodic tasks started (sharding disabled)")
+	}
 }
 
 func startHealthCheckRoutine(s *discordgo.Session, shardManager *services.AppShardManager) {
@@ -441,6 +449,11 @@ func startHealthCheckRoutine(s *discordgo.Session, shardManager *services.AppSha
 	for range ticker.C {
 		healthy := true
 		issues := []string{}
+
+		if !shardManager.Initialized {
+			logger.Log.Warn("Shard manager not initialized during health check, attempting to initialize")
+			shardManager.EnsureInitialized()
+		}
 
 		if s.DataReady == false {
 			logger.Log.Errorf("Shard %d Discord connection is not ready", shardManager.ShardID)
@@ -455,9 +468,9 @@ func startHealthCheckRoutine(s *discordgo.Session, shardManager *services.AppSha
 		}
 
 		if !shardManager.Initialized {
-			logger.Log.Errorf("Shard %d manager is not initialized", shardManager.ShardID)
+			logger.Log.Errorf("Shard %d manager could not be initialized", shardManager.ShardID)
 			healthy = false
-			issues = append(issues, "Shard manager not initialized")
+			issues = append(issues, "Shard manager initialization failed")
 		}
 
 		if time.Now().Minute()%5 == 0 {

--- a/main.go
+++ b/main.go
@@ -288,22 +288,31 @@ func startPeriodicTasks(ctx context.Context, s *discordgo.Session, shardManager 
 					return
 				case <-updateTicker.C:
 					logger.Log.Debug("Leader shard processing consolidated daily updates")
-					var users []models.UserSettings
-					if err := database.DB.Find(&users).Error; err != nil {
+
+					var allUsers []models.UserSettings
+					if err := database.DB.Find(&allUsers).Error; err != nil {
 						logger.Log.WithError(err).Error("Failed to fetch users for consolidated updates")
 						continue
 					}
-					for _, user := range users {
-						if !shardManager.IsUserAssignedToShard(user.UserID) {
 
-							processedUsers := 0
+					users := services.FilterUserSettingsByShardAssignment(allUsers)
+					logger.Log.Debugf("Processing daily updates for %d users assigned to this shard (filtered from %d total)", len(users), len(allUsers))
+
+					processedUsers := 0
+					for _, user := range users {
+						if user.UserID == "" {
+							continue
+						}
+
+						if !shardManager.IsUserAssignedToShard(user.UserID) {
+							logger.Log.Debugf("User %s no longer assigned to this shard, skipping", user.UserID)
 							continue
 						}
 
 						var accounts []models.Account
 						if err := database.DB.Where("user_id = ? AND is_check_disabled = ? AND is_expired_cookie = ?",
 							user.UserID, false, false).Find(&accounts).Error; err != nil {
-							logger.Log.WithError(err).Error("Failed to fetch accounts for user")
+							logger.Log.WithError(err).Errorf("Failed to fetch accounts for user %s", user.UserID)
 							continue
 						}
 
@@ -360,9 +369,19 @@ func startPeriodicTasks(ctx context.Context, s *discordgo.Session, shardManager 
 				case <-ctx.Done():
 					return
 				case <-userCleanupTicker.C:
+					logger.Log.Info("Leader shard starting comprehensive cleanup")
+
 					services.CleanupInactiveUsers()
-					logger.Log.Info("Leader shard completed inactive users cleanup")
+					logger.Log.Info("Completed inactive users cleanup")
+
+					services.CleanupUsersByShardAssignment()
+					logger.Log.Info("Completed shard assignment cleanup")
+
+					services.CleanupOldShardInfo()
+					logger.Log.Info("Completed shard info cleanup")
+
 					services.LogInstallationStats(s)
+					logger.Log.Info("Leader shard completed comprehensive cleanup")
 				}
 			}
 		}()
@@ -376,8 +395,18 @@ func startPeriodicTasks(ctx context.Context, s *discordgo.Session, shardManager 
 				case <-ctx.Done():
 					return
 				case <-analyticsTicker.C:
+					logger.Log.Info("Leader shard starting analytics cleanup")
 					if err := services.CleanupOldAnalyticsData(cfg.Admin.RetentionDays); err != nil {
 						logger.Log.WithError(err).Error("Failed to clean up old analytics data")
+					} else {
+						logger.Log.Info("Completed analytics data cleanup")
+					}
+
+					stats, err := services.ValidateUserShardAssignments()
+					if err != nil {
+						logger.Log.WithError(err).Error("Failed to validate user shard assignments")
+					} else {
+						logger.Log.Infof("Shard assignment validation: %+v", stats)
 					}
 				}
 			}
@@ -410,21 +439,42 @@ func startHealthCheckRoutine(s *discordgo.Session, shardManager *services.AppSha
 	defer ticker.Stop()
 
 	for range ticker.C {
+		healthy := true
+		issues := []string{}
+
 		if s.DataReady == false {
 			logger.Log.Errorf("Shard %d Discord connection is not ready", shardManager.ShardID)
-			continue
+			healthy = false
+			issues = append(issues, "Discord connection not ready")
 		}
 
 		if err := database.CheckConnection(); err != nil {
 			logger.Log.WithError(err).Errorf("Shard %d database health check failed", shardManager.ShardID)
-			continue
+			healthy = false
+			issues = append(issues, fmt.Sprintf("Database connection failed: %v", err))
 		}
 
 		if !shardManager.Initialized {
 			logger.Log.Errorf("Shard %d manager is not initialized", shardManager.ShardID)
-			continue
+			healthy = false
+			issues = append(issues, "Shard manager not initialized")
 		}
 
-		logger.Log.Debugf("Shard %d health check passed", shardManager.ShardID)
+		if time.Now().Minute()%5 == 0 {
+			services.PerformShardHealthCheck()
+		}
+
+		if healthy {
+			logger.Log.Debugf("Shard %d health check passed", shardManager.ShardID)
+		} else {
+			logger.Log.Errorf("Shard %d health check failed: %v", shardManager.ShardID, issues)
+
+			services.LogAnalyticsEvent("health_check_failed", "", "", "", "failed",
+				shardManager.ShardID, shardManager.InstanceID, map[string]interface{}{
+					"issues":            issues,
+					"discord_ready":     s.DataReady,
+					"shard_initialized": shardManager.Initialized,
+				})
+		}
 	}
 }

--- a/models/models.go
+++ b/models/models.go
@@ -116,10 +116,13 @@ type ShardInfo struct { // Information about application shards
 	gorm.Model
 	ShardID       int       `gorm:"index"` // The shard ID
 	TotalShards   int       // The total number of shards
-	InstanceID    string    `gorm:"uniqueIndex"`      // Unique identifier for this instance
-	LastHeartbeat time.Time `gorm:"index"`            // Last time this shard reported as alive
-	Status        string    `gorm:"default:'active'"` // Status of this shard: active, inactive
-	Stats         string    `gorm:"type:text"`        // JSON encoded stats about this shard
+	InstanceID    string    `gorm:"uniqueIndex"`            // Unique identifier for this instance
+	LastHeartbeat time.Time `gorm:"index"`                  // Last time this shard reported as alive
+	Status        string    `gorm:"default:'active';index"` // Status of this shard: active, inactive, shutdown
+	Stats         string    `gorm:"type:text"`              // JSON encoded stats about this shard
+	StartupTime   time.Time `gorm:"index"`                  // When this shard instance started
+	ProcessID     int64     // Process ID of the shard instance
+	Hostname      string    `gorm:"index"` // Hostname where shard is running
 }
 
 type ProxyStats struct { // Statistics about HTTP proxies

--- a/services/account_manager.go
+++ b/services/account_manager.go
@@ -157,13 +157,13 @@ func processUserAccountsWithStats(s *discordgo.Session, userID string, accounts 
 
 		if err != nil {
 			logger.Log.WithError(err).Errorf("Failed to check account %s: %v", account.Title, err)
-			LogAccountCheck(account.ID, userID, models.StatusUnknown, false, userSettings.PreferredCaptchaProvider, 0, responseTime)
+			LogAccountCheck(account.ID, userID, false, models.StatusUnknown, responseTime, userSettings.PreferredCaptchaProvider, 0, "Check failed")
 			handleCheckError(s, &account, err)
 			failedChecks++
 			continue
 		}
 
-		LogAccountCheck(account.ID, userID, result, true, userSettings.PreferredCaptchaProvider, 0, responseTime)
+		LogAccountCheck(account.ID, userID, true, result, responseTime, userSettings.PreferredCaptchaProvider, 0, "")
 		successfulChecks++
 		now := time.Now()
 		account.LastCheck = now.Unix()
@@ -249,12 +249,12 @@ func processUserAccounts(s *discordgo.Session, userID string, accounts []models.
 
 		if err != nil {
 			logger.Log.WithError(err).Errorf("Failed to check account %s: %v", account.Title, err)
-			LogAccountCheck(account.ID, userID, models.StatusUnknown, false, userSettings.PreferredCaptchaProvider, 0, responseTime)
+			LogAccountCheck(account.ID, userID, false, models.StatusUnknown, responseTime, userSettings.PreferredCaptchaProvider, 0, "Check failed")
 			handleCheckError(s, &account, err)
 			continue
 		}
 
-		LogAccountCheck(account.ID, userID, result, true, userSettings.PreferredCaptchaProvider, 0, responseTime)
+		LogAccountCheck(account.ID, userID, true, result, responseTime, userSettings.PreferredCaptchaProvider, 0, "")
 		now := time.Now()
 		account.LastCheck = now.Unix()
 		account.LastSuccessfulCheck = now

--- a/services/analytics.go
+++ b/services/analytics.go
@@ -1,10 +1,8 @@
 package services
 
 import (
-	"fmt"
 	"time"
 
-	"github.com/bradselph/CODStatusBot/configuration"
 	"github.com/bradselph/CODStatusBot/database"
 	"github.com/bradselph/CODStatusBot/logger"
 	"github.com/bradselph/CODStatusBot/models"
@@ -12,420 +10,247 @@ import (
 
 func LogCommandExecution(commandName, userID, guildID string, success bool, responseTimeMs int64, errorDetails string) {
 	shardMgr := GetAppShardManager()
-	shardID := 0
-	instanceID := ""
 
-	if shardMgr.Initialized {
-		shardID = shardMgr.ShardID
-		instanceID = shardMgr.InstanceID
+	metadata := map[string]interface{}{
+		"success":          success,
+		"response_time_ms": responseTimeMs,
+		"command_name":     commandName,
 	}
 
-	analytics := models.Analytics{
-		Type:           "command",
-		UserID:         userID,
-		GuildID:        guildID,
-		CommandName:    commandName,
-		Success:        success,
-		ResponseTimeMs: responseTimeMs,
-		ErrorDetails:   errorDetails,
-		Timestamp:      time.Now(),
-		Day:            time.Now().Format("2006-01-02"),
-		ShardID:        shardID,
-		InstanceID:     instanceID,
+	if errorDetails != "" {
+		metadata["error_details"] = errorDetails
 	}
 
-	if err := database.DB.Create(&analytics).Error; err != nil {
-		logger.Log.WithError(err).Error("Failed to log command analytics")
+	status := "success"
+	if !success {
+		status = "error"
 	}
 
-	updateCommandStatistics(commandName, success, responseTimeMs)
+	LogAnalyticsEvent("command_usage", userID, guildID, commandName, status,
+		shardMgr.ShardID, shardMgr.InstanceID, metadata)
 }
 
-func LogAccountCheck(accountID uint, userID string, status models.Status, success bool,
-	captchaProvider string, captchaCost float64, responseTimeMs int64) {
+func LogShardEvent(eventType string, metadata map[string]interface{}) {
 	shardMgr := GetAppShardManager()
-	shardID := 0
-	instanceID := ""
 
-	if shardMgr.Initialized {
-		shardID = shardMgr.ShardID
-		instanceID = shardMgr.InstanceID
+	if metadata == nil {
+		metadata = make(map[string]interface{})
 	}
 
-	analytics := models.Analytics{
-		Type:            "account_check",
-		UserID:          userID,
-		AccountID:       accountID,
-		Status:          string(status),
-		Success:         success,
-		ResponseTimeMs:  responseTimeMs,
-		CaptchaProvider: captchaProvider,
-		CaptchaCost:     captchaCost,
-		Timestamp:       time.Now(),
-		Day:             time.Now().Format("2006-01-02"),
-		ShardID:         shardID,
-		InstanceID:      instanceID,
-	}
+	metadata["shard_id"] = shardMgr.ShardID
+	metadata["total_shards"] = shardMgr.TotalShards
+	metadata["is_leader"] = shardMgr.IsLeader()
 
-	if err := database.DB.Create(&analytics).Error; err != nil {
-		logger.Log.WithError(err).Error("Failed to log account check analytics")
-	}
-
-	updateBotStatistics("account_check", success, responseTimeMs)
-}
-
-func LogStatusChange(accountID uint, userID string, status models.Status,
-	previousStatus models.Status) {
-	shardMgr := GetAppShardManager()
-	shardID := 0
-	instanceID := ""
-
-	if shardMgr.Initialized {
-		shardID = shardMgr.ShardID
-		instanceID = shardMgr.InstanceID
-	}
-
-	analytics := models.Analytics{
-		Type:           "status_change",
-		UserID:         userID,
-		AccountID:      accountID,
-		Status:         string(status),
-		PreviousStatus: string(previousStatus),
-		Success:        true,
-		Timestamp:      time.Now(),
-		Day:            time.Now().Format("2006-01-02"),
-		ShardID:        shardID,
-		InstanceID:     instanceID,
-	}
-
-	if err := database.DB.Create(&analytics).Error; err != nil {
-		logger.Log.WithError(err).Error("Failed to log status change analytics")
-	}
-
-	updateBotStatistics("status_change", true, 0)
-}
-
-func LogAccountStatusCheck(accountID uint, userID string, status models.Status, initiator string, errorDetails string) {
-	now := time.Now()
-	statusLog := models.Ban{
-		AccountID:    accountID,
-		Status:       status,
-		LogType:      "check_status",
-		Message:      fmt.Sprintf("Account status checked: %s", status),
-		Timestamp:    now,
-		Initiator:    initiator,
-		ErrorDetails: errorDetails,
-	}
-
-	if err := database.DB.Create(&statusLog).Error; err != nil {
-		logger.Log.WithError(err).Error("Failed to create account status check log")
-	} else {
-		logger.Log.Infof("Created status check log for account %d: %s", accountID, status)
-	}
-}
-
-func LogNotification(userID string, accountID uint, notificationType string, success bool) {
-	shardMgr := GetAppShardManager()
-	shardID := 0
-	instanceID := ""
-
-	if shardMgr.Initialized {
-		shardID = shardMgr.ShardID
-		instanceID = shardMgr.InstanceID
-	}
-
-	analytics := models.Analytics{
-		Type:        "notification",
-		UserID:      userID,
-		AccountID:   accountID,
-		CommandName: notificationType,
-		Success:     success,
-		Timestamp:   time.Now(),
-		Day:         time.Now().Format("2006-01-02"),
-		ShardID:     shardID,
-		InstanceID:  instanceID,
-	}
-
-	if err := database.DB.Create(&analytics).Error; err != nil {
-		logger.Log.WithError(err).Error("Failed to log notification analytics")
-	}
-
-	updateBotStatistics("notification", success, 0)
-}
-
-func updateBotStatistics(eventType string, success bool, responseTimeMs int64) {
-	tableExists := database.DB.Migrator().HasTable(&models.BotStatistics{})
-	if !tableExists {
-		logger.Log.Warn("Bot statistics table doesn't exist yet - skipping update")
-		return
-	}
-
-	today := time.Now().Format("2006-01-02")
-	todayTime, _ := time.Parse("2006-01-02", today)
-
-	var stats models.BotStatistics
-	stats.Date = todayTime
-
-	result := database.DB.Where("date = ?", todayTime).FirstOrCreate(&stats)
-	if result.Error != nil {
-		logger.Log.WithError(result.Error).Error("Failed to get/create bot statistics")
-		return
-	}
-
-	switch eventType {
-	case "command":
-		stats.CommandsUsed++
-	case "account_check":
-		stats.AccountsChecked++
-		if !success {
-			stats.CaptchaErrors++
-		} else {
-			stats.CaptchaUsed++
-		}
-
-		if responseTimeMs > 0 {
-			if stats.AverageCheckTime == 0 {
-				stats.AverageCheckTime = float64(responseTimeMs)
-			} else {
-				stats.AverageCheckTime = (stats.AverageCheckTime*float64(stats.AccountsChecked-1) + float64(responseTimeMs)) / float64(stats.AccountsChecked)
-			}
-		}
-	case "status_change":
-		stats.StatusChanges++
-	}
-
-	var activeUsers int64
-	database.DB.Model(&models.Analytics{}).
-		Where("day = ?", today).
-		Distinct("user_id").
-		Count(&activeUsers)
-	stats.ActiveUsers = int(activeUsers)
-
-	if err := database.DB.Save(&stats).Error; err != nil {
-		logger.Log.WithError(err).Error("Failed to update bot statistics")
-	}
-}
-
-func updateCommandStatistics(commandName string, success bool, responseTimeMs int64) {
-	tableExists := database.DB.Migrator().HasTable(&models.CommandStatistics{})
-	if !tableExists {
-		logger.Log.Warn("Command statistics table doesn't exist yet - skipping update")
-		return
-	}
-
-	today := time.Now().Format("2006-01-02")
-	todayTime, _ := time.Parse("2006-01-02", today)
-
-	var stats models.CommandStatistics
-	stats.CommandName = commandName
-	stats.Date = todayTime
-
-	result := database.DB.Where("date = ? AND command_name = ?", todayTime, commandName).FirstOrCreate(&stats)
-	if result.Error != nil {
-		logger.Log.WithError(result.Error).Error("Failed to get/create command statistics")
-		return
-	}
-
-	stats.UsageCount++
-	if success {
-		stats.SuccessCount++
-	} else {
-		stats.ErrorCount++
-	}
-
-	if responseTimeMs > 0 {
-		if stats.AverageTimeMs == 0 {
-			stats.AverageTimeMs = float64(responseTimeMs)
-		} else {
-			stats.AverageTimeMs = (stats.AverageTimeMs*float64(stats.UsageCount-1) + float64(responseTimeMs)) / float64(stats.UsageCount)
-		}
-	}
-
-	if err := database.DB.Save(&stats).Error; err != nil {
-		logger.Log.WithError(err).Error("Failed to update command statistics")
-	}
-}
-
-func GetDailyStats(day string) (map[string]interface{}, error) {
-	var stats struct {
-		CommandCount      int64
-		AccountCheckCount int64
-		StatusChangeCount int64
-		NotificationCount int64
-		UniqueUsers       int64
-		SuccessRate       float64
-		AvgResponseTime   float64
-	}
-
-	if err := database.DB.Model(&models.Analytics{}).
-		Where("day = ? AND type = ?", day, "command").
-		Count(&stats.CommandCount).Error; err != nil {
-		return nil, err
-	}
-
-	if err := database.DB.Model(&models.Analytics{}).
-		Where("day = ? AND type = ?", day, "account_check").
-		Count(&stats.AccountCheckCount).Error; err != nil {
-		return nil, err
-	}
-
-	if err := database.DB.Model(&models.Analytics{}).
-		Where("day = ? AND type = ?", day, "status_change").
-		Count(&stats.StatusChangeCount).Error; err != nil {
-		return nil, err
-	}
-
-	if err := database.DB.Model(&models.Analytics{}).
-		Where("day = ? AND type = ?", day, "notification").
-		Count(&stats.NotificationCount).Error; err != nil {
-		return nil, err
-	}
-
-	database.DB.Model(&models.Analytics{}).
-		Where("day = ?", day).
-		Distinct("user_id").
-		Count(&stats.UniqueUsers)
-
-	var successCount int64
-	var totalCount int64
-	database.DB.Model(&models.Analytics{}).
-		Where("day = ?", day).
-		Count(&totalCount)
-	database.DB.Model(&models.Analytics{}).
-		Where("day = ? AND success = ?", day, true).
-		Count(&successCount)
-
-	if totalCount > 0 {
-		stats.SuccessRate = float64(successCount) / float64(totalCount) * 100
-	}
-
-	database.DB.Model(&models.Analytics{}).
-		Where("day = ?", day).
-		Select("AVG(response_time_ms) as avg_response_time").
-		Scan(&stats.AvgResponseTime)
-
-	var botStats models.BotStatistics
-	dayTime, _ := time.Parse("2006-01-02", day)
-	if err := database.DB.Where("date = ?", dayTime).First(&botStats).Error; err == nil {
-		return map[string]interface{}{
-			"date":                day,
-			"command_count":       botStats.CommandsUsed,
-			"account_check_count": botStats.AccountsChecked,
-			"status_change_count": botStats.StatusChanges,
-			"captcha_used":        botStats.CaptchaUsed,
-			"captcha_errors":      botStats.CaptchaErrors,
-			"unique_users":        botStats.ActiveUsers,
-			"avg_check_time":      botStats.AverageCheckTime,
-		}, nil
-	}
-
-	return map[string]interface{}{
-		"date":                day,
-		"command_count":       stats.CommandCount,
-		"account_check_count": stats.AccountCheckCount,
-		"status_change_count": stats.StatusChangeCount,
-		"notification_count":  stats.NotificationCount,
-		"unique_users":        stats.UniqueUsers,
-		"success_rate":        stats.SuccessRate,
-		"avg_response_time":   stats.AvgResponseTime,
-	}, nil
-}
-
-func GetUserStats(userID string, days int) (map[string]interface{}, error) {
-	startDate := time.Now().AddDate(0, 0, -days)
-	startDateStr := startDate.Format("2006-01-02")
-
-	var stats struct {
-		CommandCount      int64
-		AccountCheckCount int64
-		StatusChangeCount int64
-		SuccessRate       float64
-		CaptchaCost       float64
-	}
-
-	if err := database.DB.Model(&models.Analytics{}).
-		Where("user_id = ? AND type = ? AND day >= ?", userID, "command", startDateStr).
-		Count(&stats.CommandCount).Error; err != nil {
-		return nil, err
-	}
-
-	if err := database.DB.Model(&models.Analytics{}).
-		Where("user_id = ? AND type = ? AND day >= ?", userID, "account_check", startDateStr).
-		Count(&stats.AccountCheckCount).Error; err != nil {
-		return nil, err
-	}
-
-	if err := database.DB.Model(&models.Analytics{}).
-		Where("user_id = ? AND type = ? AND day >= ?", userID, "status_change", startDateStr).
-		Count(&stats.StatusChangeCount).Error; err != nil {
-		return nil, err
-	}
-
-	var successCount int64
-	var totalCount int64
-	database.DB.Model(&models.Analytics{}).
-		Where("user_id = ? AND day >= ?", userID, startDateStr).
-		Count(&totalCount)
-	database.DB.Model(&models.Analytics{}).
-		Where("user_id = ? AND success = ? AND day >= ?", userID, true, startDateStr).
-		Count(&successCount)
-
-	if totalCount > 0 {
-		stats.SuccessRate = float64(successCount) / float64(totalCount) * 100
-	}
-
-	database.DB.Model(&models.Analytics{}).
-		Where("user_id = ? AND day >= ?", userID, startDateStr).
-		Select("SUM(captcha_cost) as captcha_cost").
-		Scan(&stats.CaptchaCost)
-
-	var commands []struct {
-		CommandName string `json:"command_name"`
-		Count       int64  `json:"count"`
-	}
-
-	database.DB.Model(&models.Analytics{}).
-		Select("command_name, COUNT(*) as count").
-		Where("user_id = ? AND type = ? AND day >= ?", userID, "command", startDateStr).
-		Group("command_name").
-		Order("count DESC").
-		Limit(10).
-		Scan(&commands)
-
-	return map[string]interface{}{
-		"user_id":             userID,
-		"days":                days,
-		"command_count":       stats.CommandCount,
-		"account_check_count": stats.AccountCheckCount,
-		"status_change_count": stats.StatusChangeCount,
-		"success_rate":        stats.SuccessRate,
-		"captcha_cost":        stats.CaptchaCost,
-		"top_commands":        commands,
-	}, nil
+	LogAnalyticsEvent(eventType, "", "", "", "info",
+		shardMgr.ShardID, shardMgr.InstanceID, metadata)
 }
 
 func CleanupOldAnalyticsData(retentionDays int) error {
-	cfg := configuration.Get()
-
 	if retentionDays <= 0 {
-		retentionDays = cfg.Admin.RetentionDays
+		logger.Log.Warn("Invalid retention days for analytics cleanup, skipping")
+		return nil
 	}
 
 	cutoffDate := time.Now().AddDate(0, 0, -retentionDays)
-	cutoffDateStr := cutoffDate.Format("2006-01-02")
 
-	if err := database.DB.Where("day < ?", cutoffDateStr).Delete(&models.Analytics{}).Error; err != nil {
-		return fmt.Errorf("failed to clean up old analytics data: %w", err)
+	var oldRecordsCount int64
+	if err := database.DB.Model(&models.Analytics{}).
+		Where("timestamp < ?", cutoffDate).Count(&oldRecordsCount).Error; err != nil {
+		return err
 	}
 
-	if err := database.DB.Where("date < ?", cutoffDate).Delete(&models.BotStatistics{}).Error; err != nil {
-		return fmt.Errorf("failed to clean up old bot statistics: %w", err)
+	if oldRecordsCount == 0 {
+		logger.Log.Debug("No old analytics data to clean up")
+		return nil
 	}
 
-	if err := database.DB.Where("date < ?", cutoffDate).Delete(&models.CommandStatistics{}).Error; err != nil {
-		return fmt.Errorf("failed to clean up old command statistics: %w", err)
+	logger.Log.Infof("Cleaning up %d analytics records older than %d days", oldRecordsCount, retentionDays)
+
+	result := database.DB.Where("timestamp < ?", cutoffDate).Delete(&models.Analytics{})
+	if result.Error != nil {
+		return result.Error
 	}
 
-	logger.Log.Infof("Cleaned up analytics data older than %s", cutoffDateStr)
+	logger.Log.Infof("Successfully cleaned up %d old analytics records", result.RowsAffected)
+
+	shardMgr := GetAppShardManager()
+	metadata := map[string]interface{}{
+		"cleaned_records": result.RowsAffected,
+		"retention_days":  retentionDays,
+		"cutoff_date":     cutoffDate.Format("2006-01-02"),
+	}
+
+	LogAnalyticsEvent("analytics_cleanup", "", "", "", "success",
+		shardMgr.ShardID, shardMgr.InstanceID, metadata)
+
 	return nil
+}
+
+func GetAnalyticsStats(days int) (map[string]interface{}, error) {
+	if days <= 0 {
+		days = 7
+	}
+
+	startDate := time.Now().AddDate(0, 0, -days)
+
+	stats := map[string]interface{}{
+		"period_days": days,
+		"start_date":  startDate.Format("2006-01-02"),
+		"end_date":    time.Now().Format("2006-01-02"),
+	}
+
+	var totalEvents int64
+	if err := database.DB.Model(&models.Analytics{}).
+		Where("timestamp >= ?", startDate).Count(&totalEvents).Error; err != nil {
+		return stats, err
+	}
+	stats["total_events"] = totalEvents
+
+	var eventTypes []struct {
+		Type  string `json:"type"`
+		Count int    `json:"count"`
+	}
+	if err := database.DB.Model(&models.Analytics{}).
+		Select("type, COUNT(*) as count").
+		Where("timestamp >= ?", startDate).
+		Group("type").
+		Scan(&eventTypes).Error; err != nil {
+		return stats, err
+	}
+	stats["events_by_type"] = eventTypes
+
+	var shardDistribution []struct {
+		ShardID int `json:"shard_id"`
+		Count   int `json:"count"`
+	}
+	if err := database.DB.Model(&models.Analytics{}).
+		Select("shard_id, COUNT(*) as count").
+		Where("timestamp >= ?", startDate).
+		Group("shard_id").
+		Scan(&shardDistribution).Error; err != nil {
+		return stats, err
+	}
+	stats["events_by_shard"] = shardDistribution
+
+	var successCount int64
+	if err := database.DB.Model(&models.Analytics{}).
+		Where("timestamp >= ? AND success = ?", startDate, true).Count(&successCount).Error; err != nil {
+		return stats, err
+	}
+
+	successRate := float64(0)
+	if totalEvents > 0 {
+		successRate = float64(successCount) / float64(totalEvents) * 100
+	}
+	stats["success_rate_percent"] = successRate
+
+	return stats, nil
+}
+
+func GetDailyStats(date string) (map[string]interface{}, error) {
+	if date == "" {
+		date = time.Now().Format("2006-01-02")
+	}
+
+	stats := map[string]interface{}{
+		"date": date,
+	}
+
+	var commandCount int64
+	if err := database.DB.Model(&models.Analytics{}).
+		Where("type = ? AND day = ?", "command_usage", date).
+		Count(&commandCount).Error; err != nil {
+		return stats, err
+	}
+	stats["command_count"] = commandCount
+
+	var accountCheckCount int64
+	if err := database.DB.Model(&models.Analytics{}).
+		Where("type = ? AND day = ?", "account_check", date).
+		Count(&accountCheckCount).Error; err != nil {
+		return stats, err
+	}
+	stats["account_check_count"] = accountCheckCount
+
+	var statusChangeCount int64
+	if err := database.DB.Model(&models.Analytics{}).
+		Where("type = ? AND day = ?", "status_change", date).
+		Count(&statusChangeCount).Error; err != nil {
+		return stats, err
+	}
+	stats["status_change_count"] = statusChangeCount
+
+	var uniqueUsers int64
+	if err := database.DB.Model(&models.Analytics{}).
+		Where("day = ?", date).
+		Distinct("user_id").
+		Count(&uniqueUsers).Error; err != nil {
+		return stats, err
+	}
+	stats["unique_users"] = uniqueUsers
+
+	var successfulEvents int64
+	if err := database.DB.Model(&models.Analytics{}).
+		Where("day = ? AND success = ?", date, true).
+		Count(&successfulEvents).Error; err != nil {
+		return stats, err
+	}
+
+	var totalEvents int64
+	if err := database.DB.Model(&models.Analytics{}).
+		Where("day = ?", date).
+		Count(&totalEvents).Error; err != nil {
+		return stats, err
+	}
+
+	successRate := float64(0)
+	if totalEvents > 0 {
+		successRate = float64(successfulEvents) / float64(totalEvents) * 100
+	}
+	stats["success_rate_percent"] = successRate
+	stats["total_events"] = totalEvents
+	stats["successful_events"] = successfulEvents
+
+	return stats, nil
+}
+
+func GetShardAnalytics(days int) (map[string]interface{}, error) {
+	shardMgr := GetAppShardManager()
+
+	if days <= 0 {
+		days = 7
+	}
+
+	startDate := time.Now().AddDate(0, 0, -days)
+
+	stats := map[string]interface{}{
+		"shard_id":    shardMgr.ShardID,
+		"instance_id": shardMgr.InstanceID,
+		"period_days": days,
+		"start_date":  startDate.Format("2006-01-02"),
+		"end_date":    time.Now().Format("2006-01-02"),
+	}
+
+	var totalEvents int64
+	if err := database.DB.Model(&models.Analytics{}).
+		Where("timestamp >= ? AND shard_id = ?", startDate, shardMgr.ShardID).
+		Count(&totalEvents).Error; err != nil {
+		return stats, err
+	}
+	stats["total_events"] = totalEvents
+
+	var eventTypes []struct {
+		Type  string `json:"type"`
+		Count int    `json:"count"`
+	}
+	if err := database.DB.Model(&models.Analytics{}).
+		Select("type, COUNT(*) as count").
+		Where("timestamp >= ? AND shard_id = ?", startDate, shardMgr.ShardID).
+		Group("type").
+		Scan(&eventTypes).Error; err != nil {
+		return stats, err
+	}
+	stats["events_by_type"] = eventTypes
+
+	return stats, nil
 }

--- a/services/app_sharding.go
+++ b/services/app_sharding.go
@@ -24,6 +24,7 @@ type AppShardManager struct {
 	Initialized   bool
 	isLeader      bool
 	lastRebalance time.Time
+	rebalancing   bool
 }
 
 var appShardManager *AppShardManager
@@ -34,6 +35,7 @@ func GetAppShardManager() *AppShardManager {
 			InstanceID:    generateInstanceID(),
 			Initialized:   false,
 			lastRebalance: time.Now(),
+			rebalancing:   false,
 		}
 	}
 	return appShardManager
@@ -231,10 +233,24 @@ func (asm *AppShardManager) performMaintenance() {
 		return
 	}
 
+	asm.Lock()
+	if asm.rebalancing {
+		asm.Unlock()
+		return
+	}
+	asm.rebalancing = true
+	asm.Unlock()
+
+	defer func() {
+		asm.Lock()
+		asm.rebalancing = false
+		asm.lastRebalance = time.Now()
+		asm.Unlock()
+	}()
+
 	asm.healShards()
 	asm.rebalanceShards()
 	asm.electLeader()
-	asm.lastRebalance = time.Now()
 }
 
 func (asm *AppShardManager) healShards() {
@@ -380,6 +396,11 @@ func (asm *AppShardManager) cleanup() {
 }
 
 func (asm *AppShardManager) GuildBelongsToInstance(guildID string) bool {
+	if guildID == "" {
+		logger.Log.Debug("Empty guildID provided to GuildBelongsToInstance")
+		return false
+	}
+
 	asm.RLock()
 	defer asm.RUnlock()
 
@@ -398,6 +419,11 @@ func (asm *AppShardManager) GuildBelongsToInstance(guildID string) bool {
 }
 
 func (asm *AppShardManager) GetGuildShardID(guildID string) int {
+	if guildID == "" {
+		logger.Log.Debug("Empty guildID provided to GetGuildShardID")
+		return -1
+	}
+
 	asm.RLock()
 	defer asm.RUnlock()
 
@@ -415,6 +441,11 @@ func (asm *AppShardManager) GetGuildShardID(guildID string) int {
 }
 
 func (asm *AppShardManager) ShardBelongsToInstance(userID string) bool {
+	if userID == "" {
+		logger.Log.Debug("Empty userID provided to ShardBelongsToInstance")
+		return false
+	}
+
 	asm.RLock()
 	defer asm.RUnlock()
 
@@ -427,12 +458,21 @@ func (asm *AppShardManager) ShardBelongsToInstance(userID string) bool {
 }
 
 func getUserShard(userID string, totalShards int) int {
+	if userID == "" || totalShards <= 1 {
+		return 0
+	}
+
 	hash := sha256.Sum256([]byte(userID))
 	val := binary.BigEndian.Uint64(hash[:8])
 	return int(val % uint64(totalShards))
 }
 
 func (asm *AppShardManager) GetUserShardID(userID string) int {
+	if userID == "" {
+		logger.Log.Debug("Empty userID provided to GetUserShardID")
+		return -1
+	}
+
 	asm.RLock()
 	defer asm.RUnlock()
 
@@ -466,10 +506,15 @@ func (asm *AppShardManager) GetShardingStatus() map[string]interface{} {
 		"initialized":    asm.Initialized,
 		"is_leader":      asm.isLeader,
 		"last_heartbeat": asm.HeartbeatTime,
+		"rebalancing":    asm.rebalancing,
 	}
 }
 
 func (asm *AppShardManager) FilterUsersByShardAssignment(userIDs []string) []string {
+	if len(userIDs) == 0 {
+		return userIDs
+	}
+
 	asm.RLock()
 	defer asm.RUnlock()
 
@@ -479,7 +524,7 @@ func (asm *AppShardManager) FilterUsersByShardAssignment(userIDs []string) []str
 
 	var assignedUsers []string
 	for _, userID := range userIDs {
-		if getUserShard(userID, asm.TotalShards) == asm.ShardID {
+		if userID != "" && getUserShard(userID, asm.TotalShards) == asm.ShardID {
 			assignedUsers = append(assignedUsers, userID)
 		}
 	}
@@ -488,6 +533,11 @@ func (asm *AppShardManager) FilterUsersByShardAssignment(userIDs []string) []str
 }
 
 func (asm *AppShardManager) IsUserAssignedToShard(userID string) bool {
+	if userID == "" {
+		logger.Log.Debug("Empty userID provided to IsUserAssignedToShard")
+		return false
+	}
+
 	asm.RLock()
 	defer asm.RUnlock()
 
@@ -516,7 +566,7 @@ func (asm *AppShardManager) GetShardedUserCount() (int64, error) {
 
 	var count int64
 	for _, userID := range userIDs {
-		if getUserShard(userID, asm.TotalShards) == asm.ShardID {
+		if userID != "" && getUserShard(userID, asm.TotalShards) == asm.ShardID {
 			count++
 		}
 	}
@@ -525,6 +575,10 @@ func (asm *AppShardManager) GetShardedUserCount() (int64, error) {
 }
 
 func FilterAccountsByShardAssignment(accounts []models.Account) []models.Account {
+	if len(accounts) == 0 {
+		return accounts
+	}
+
 	shardManager := GetAppShardManager()
 
 	if shardManager.TotalShards <= 1 {
@@ -533,15 +587,20 @@ func FilterAccountsByShardAssignment(accounts []models.Account) []models.Account
 
 	var filteredAccounts []models.Account
 	for _, account := range accounts {
-		if shardManager.IsUserAssignedToShard(account.UserID) {
+		if account.UserID != "" && shardManager.IsUserAssignedToShard(account.UserID) {
 			filteredAccounts = append(filteredAccounts, account)
 		}
 	}
 
+	logger.Log.Debugf("Filtered %d accounts down to %d for shard %d", len(accounts), len(filteredAccounts), shardManager.ShardID)
 	return filteredAccounts
 }
 
 func FilterUserSettingsByShardAssignment(settings []models.UserSettings) []models.UserSettings {
+	if len(settings) == 0 {
+		return settings
+	}
+
 	shardManager := GetAppShardManager()
 
 	if shardManager.TotalShards <= 1 {
@@ -550,10 +609,46 @@ func FilterUserSettingsByShardAssignment(settings []models.UserSettings) []model
 
 	var filteredSettings []models.UserSettings
 	for _, setting := range settings {
-		if shardManager.IsUserAssignedToShard(setting.UserID) {
+		if setting.UserID != "" && shardManager.IsUserAssignedToShard(setting.UserID) {
 			filteredSettings = append(filteredSettings, setting)
 		}
 	}
 
+	logger.Log.Debugf("Filtered %d user settings down to %d for shard %d", len(settings), len(filteredSettings), shardManager.ShardID)
 	return filteredSettings
+}
+
+func (asm *AppShardManager) SafeShardOperation(userID string, operation func() error) error {
+	if userID == "" {
+		return fmt.Errorf("empty userID provided for shard operation")
+	}
+
+	if !asm.IsUserAssignedToShard(userID) {
+		assignedShard := asm.GetUserShardID(userID)
+		return fmt.Errorf("user %s assigned to shard %d, current shard is %d", userID, assignedShard, asm.ShardID)
+	}
+
+	return operation()
+}
+
+func (asm *AppShardManager) GetAssignedUserIDs(userIDs []string) []string {
+	if len(userIDs) == 0 {
+		return userIDs
+	}
+
+	asm.RLock()
+	defer asm.RUnlock()
+
+	if asm.TotalShards <= 1 {
+		return userIDs
+	}
+
+	var assigned []string
+	for _, userID := range userIDs {
+		if userID != "" && getUserShard(userID, asm.TotalShards) == asm.ShardID {
+			assigned = append(assigned, userID)
+		}
+	}
+
+	return assigned
 }

--- a/services/app_sharding.go
+++ b/services/app_sharding.go
@@ -41,11 +41,42 @@ func GetAppShardManager() *AppShardManager {
 	return appShardManager
 }
 
+func (asm *AppShardManager) FallbackToSingleShard() {
+	asm.Lock()
+	defer asm.Unlock()
+
+	logger.Log.Warn("Falling back to single shard mode for maximum availability")
+	asm.ShardID = 0
+	asm.TotalShards = 1
+	asm.Initialized = true
+	asm.isLeader = true
+	asm.rebalancing = false
+}
+
+func (asm *AppShardManager) EnsureInitialized() {
+	if !asm.Initialized {
+		if err := asm.Initialize(); err != nil {
+			logger.Log.WithError(err).Warn("Shard manager initialization failed, using fallback mode")
+			asm.FallbackToSingleShard()
+		}
+	}
+}
+
 func (asm *AppShardManager) Initialize() error {
 	asm.Lock()
 	defer asm.Unlock()
 
 	if asm.Initialized {
+		return nil
+	}
+
+	shardingEnabled := os.Getenv("SHARDING_ENABLED")
+	if shardingEnabled == "false" || shardingEnabled == "" {
+		logger.Log.Info("Sharding disabled, initializing as single shard")
+		asm.ShardID = 0
+		asm.TotalShards = 1
+		asm.Initialized = true
+		asm.isLeader = true
 		return nil
 	}
 
@@ -78,15 +109,23 @@ func (asm *AppShardManager) Initialize() error {
 
 func (asm *AppShardManager) initializeAutoShard() error {
 	if !asm.ensureShardInfoTable() {
-		return fmt.Errorf("failed to ensure shard_infos table exists")
+		logger.Log.Warn("Failed to ensure shard_infos table, falling back to single shard mode")
+		asm.ShardID = 0
+		asm.TotalShards = 1
+		asm.Initialized = true
+		asm.isLeader = true
+		return nil
 	}
 
 	var activeShards []models.ShardInfo
 	if err := database.DB.Where("status = 'active' AND last_heartbeat > ?",
 		time.Now().Add(-2*time.Minute)).Find(&activeShards).Error; err != nil {
-		logger.Log.WithError(err).Error("Failed to query active shards")
+		logger.Log.WithError(err).Warn("Failed to query active shards, using single shard mode")
 		asm.ShardID = 0
 		asm.TotalShards = 1
+		asm.Initialized = true
+		asm.isLeader = true
+		return nil
 	} else {
 		asm.ShardID = len(activeShards)
 		asm.TotalShards = len(activeShards) + 1
@@ -137,7 +176,10 @@ func (asm *AppShardManager) ensureShardInfoTable() bool {
 
 func (asm *AppShardManager) registerShard() error {
 	if !asm.ensureShardInfoTable() {
-		return fmt.Errorf("failed to ensure shard_infos table exists")
+		logger.Log.Warn("Failed to ensure shard_infos table during registration, continuing without database tracking")
+		asm.Initialized = true
+		asm.isLeader = true
+		return nil
 	}
 
 	hostname, _ := os.Hostname()
@@ -159,7 +201,10 @@ func (asm *AppShardManager) registerShard() error {
 	if err := database.DB.Where("instance_id = ?", asm.InstanceID).
 		Assign(shardInfo).
 		FirstOrCreate(&shardInfo).Error; err != nil {
-		return fmt.Errorf("failed to register shard: %w", err)
+		logger.Log.WithError(err).Warn("Failed to register shard in database, continuing without database tracking")
+		asm.Initialized = true
+		asm.isLeader = true
+		return nil
 	}
 
 	logger.Log.Infof("Registered application shard %d of %d with instance ID %s on host %s (PID: %d)",
@@ -581,7 +626,7 @@ func FilterAccountsByShardAssignment(accounts []models.Account) []models.Account
 
 	shardManager := GetAppShardManager()
 
-	if shardManager.TotalShards <= 1 {
+	if !shardManager.Initialized || shardManager.TotalShards <= 1 {
 		return accounts
 	}
 
@@ -603,7 +648,7 @@ func FilterUserSettingsByShardAssignment(settings []models.UserSettings) []model
 
 	shardManager := GetAppShardManager()
 
-	if shardManager.TotalShards <= 1 {
+	if !shardManager.Initialized || shardManager.TotalShards <= 1 {
 		return settings
 	}
 

--- a/services/app_sharding.go
+++ b/services/app_sharding.go
@@ -22,6 +22,8 @@ type AppShardManager struct {
 	InstanceID    string
 	HeartbeatTime time.Time
 	Initialized   bool
+	isLeader      bool
+	lastRebalance time.Time
 }
 
 var appShardManager *AppShardManager
@@ -29,8 +31,9 @@ var appShardManager *AppShardManager
 func GetAppShardManager() *AppShardManager {
 	if appShardManager == nil {
 		appShardManager = &AppShardManager{
-			InstanceID:  generateInstanceID(),
-			Initialized: false,
+			InstanceID:    generateInstanceID(),
+			Initialized:   false,
+			lastRebalance: time.Now(),
 		}
 	}
 	return appShardManager
@@ -40,32 +43,64 @@ func (asm *AppShardManager) Initialize() error {
 	asm.Lock()
 	defer asm.Unlock()
 
+	if asm.Initialized {
+		return nil
+	}
+
 	shardID := os.Getenv("SHARD_ID")
 	totalShards := os.Getenv("TOTAL_SHARDS")
 
 	if shardID == "" || totalShards == "" {
-		logger.Log.Info("No sharding configuration found, running in single-shard mode")
+		return asm.initializeAutoShard()
+	}
+
+	id, err := strconv.Atoi(shardID)
+	if err != nil {
+		return fmt.Errorf("invalid SHARD_ID: %w", err)
+	}
+
+	total, err := strconv.Atoi(totalShards)
+	if err != nil {
+		return fmt.Errorf("invalid TOTAL_SHARDS: %w", err)
+	}
+
+	if id < 0 || id >= total {
+		return fmt.Errorf("SHARD_ID must be between 0 and TOTAL_SHARDS-1")
+	}
+
+	asm.ShardID = id
+	asm.TotalShards = total
+
+	return asm.registerShard()
+}
+
+func (asm *AppShardManager) initializeAutoShard() error {
+	if !asm.ensureShardInfoTable() {
+		return fmt.Errorf("failed to ensure shard_infos table exists")
+	}
+
+	var activeShards []models.ShardInfo
+	if err := database.DB.Where("status = 'active' AND last_heartbeat > ?",
+		time.Now().Add(-2*time.Minute)).Find(&activeShards).Error; err != nil {
+		logger.Log.WithError(err).Error("Failed to query active shards")
 		asm.ShardID = 0
 		asm.TotalShards = 1
 	} else {
-		id, err := strconv.Atoi(shardID)
-		if err != nil {
-			return fmt.Errorf("invalid SHARD_ID: %w", err)
-		}
+		asm.ShardID = len(activeShards)
+		asm.TotalShards = len(activeShards) + 1
 
-		total, err := strconv.Atoi(totalShards)
-		if err != nil {
-			return fmt.Errorf("invalid TOTAL_SHARDS: %w", err)
+		for _, shard := range activeShards {
+			if shard.ShardID >= asm.ShardID {
+				asm.ShardID = shard.ShardID + 1
+			}
 		}
-
-		if id < 0 || id >= total {
-			return fmt.Errorf("SHARD_ID must be between 0 and TOTAL_SHARDS-1")
-		}
-
-		asm.ShardID = id
-		asm.TotalShards = total
 	}
 
+	logger.Log.Infof("Auto-assigned shard %d of %d", asm.ShardID, asm.TotalShards)
+	return asm.registerShard()
+}
+
+func (asm *AppShardManager) ensureShardInfoTable() bool {
 	if !database.DB.Migrator().HasTable("shard_infos") {
 		logger.Log.Warn("shard_infos table does not exist, creating it manually")
 		shardInfosTableSQL := `CREATE TABLE IF NOT EXISTS shard_infos (
@@ -79,16 +114,33 @@ func (asm *AppShardManager) Initialize() error {
 			last_heartbeat datetime(3) NULL,
 			status varchar(191) DEFAULT 'active',
 			stats text,
+			startup_time datetime(3),
+			process_id bigint,
+			hostname varchar(255),
 			INDEX idx_shard_infos_deleted_at (deleted_at),
 			INDEX idx_shard_infos_shard_id (shard_id),
 			UNIQUE INDEX idx_shard_infos_instance_id (instance_id),
-			INDEX idx_shard_infos_last_heartbeat (last_heartbeat)
+			INDEX idx_shard_infos_last_heartbeat (last_heartbeat),
+			INDEX idx_shard_infos_status (status)
 		)`
 
 		if err := database.DB.Exec(shardInfosTableSQL).Error; err != nil {
-			return fmt.Errorf("failed to create shard_infos table: %w", err)
+			logger.Log.WithError(err).Error("Failed to create shard_infos table")
+			return false
 		}
 		logger.Log.Info("Created shard_infos table successfully")
+	}
+	return true
+}
+
+func (asm *AppShardManager) registerShard() error {
+	if !asm.ensureShardInfoTable() {
+		return fmt.Errorf("failed to ensure shard_infos table exists")
+	}
+
+	hostname, _ := os.Hostname()
+	if hostname == "" {
+		hostname = "unknown"
 	}
 
 	shardInfo := models.ShardInfo{
@@ -97,6 +149,9 @@ func (asm *AppShardManager) Initialize() error {
 		InstanceID:    asm.InstanceID,
 		LastHeartbeat: time.Now(),
 		Status:        "active",
+		StartupTime:   time.Now(),
+		ProcessID:     int64(os.Getpid()),
+		Hostname:      hostname,
 	}
 
 	if err := database.DB.Where("instance_id = ?", asm.InstanceID).
@@ -105,8 +160,8 @@ func (asm *AppShardManager) Initialize() error {
 		return fmt.Errorf("failed to register shard: %w", err)
 	}
 
-	logger.Log.Infof("Initialized application shard %d of %d with instance ID %s",
-		asm.ShardID, asm.TotalShards, asm.InstanceID)
+	logger.Log.Infof("Registered application shard %d of %d with instance ID %s on host %s (PID: %d)",
+		asm.ShardID, asm.TotalShards, asm.InstanceID, hostname, os.Getpid())
 
 	asm.Initialized = true
 	return nil
@@ -120,23 +175,29 @@ func (asm *AppShardManager) StartHeartbeat(ctx context.Context) {
 		}
 	}
 
-	ticker := time.NewTicker(30 * time.Second)
+	ticker := time.NewTicker(15 * time.Second)
+	rebalanceTicker := time.NewTicker(60 * time.Second)
+
 	go func() {
 		defer ticker.Stop()
+		defer rebalanceTicker.Stop()
+
 		for {
 			select {
 			case <-ctx.Done():
+				asm.cleanup()
 				return
 			case <-ticker.C:
 				if err := asm.updateHeartbeat(); err != nil {
 					logger.Log.WithError(err).Error("Failed to update shard heartbeat")
 				}
-				asm.healShards()
+			case <-rebalanceTicker.C:
+				asm.performMaintenance()
 			}
 		}
 	}()
 
-	logger.Log.Info("Started application shard heartbeat")
+	logger.Log.Info("Started application shard heartbeat with maintenance")
 }
 
 func (asm *AppShardManager) updateHeartbeat() error {
@@ -145,20 +206,42 @@ func (asm *AppShardManager) updateHeartbeat() error {
 
 	asm.HeartbeatTime = time.Now()
 
-	return database.DB.Model(&models.ShardInfo{}).
+	result := database.DB.Model(&models.ShardInfo{}).
 		Where("instance_id = ?", asm.InstanceID).
 		Updates(map[string]interface{}{
 			"last_heartbeat": time.Now(),
 			"total_shards":   asm.TotalShards,
 			"status":         "active",
-		}).Error
+		})
+
+	if result.Error != nil {
+		return result.Error
+	}
+
+	if result.RowsAffected == 0 {
+		logger.Log.Warn("Heartbeat update affected 0 rows, re-registering shard")
+		return asm.registerShard()
+	}
+
+	return nil
+}
+
+func (asm *AppShardManager) performMaintenance() {
+	if time.Since(asm.lastRebalance) < 30*time.Second {
+		return
+	}
+
+	asm.healShards()
+	asm.rebalanceShards()
+	asm.electLeader()
+	asm.lastRebalance = time.Now()
 }
 
 func (asm *AppShardManager) healShards() {
-	heartbeatTimeout := 2 * time.Minute
+	heartbeatTimeout := 90 * time.Second
 
 	var deadShards []models.ShardInfo
-	if err := database.DB.Where("last_heartbeat < ? AND status != 'inactive'",
+	if err := database.DB.Where("last_heartbeat < ? AND status = 'active'",
 		time.Now().Add(-heartbeatTimeout)).
 		Find(&deadShards).Error; err != nil {
 		logger.Log.WithError(err).Error("Failed to query for dead shards")
@@ -166,38 +249,133 @@ func (asm *AppShardManager) healShards() {
 	}
 
 	if len(deadShards) > 0 {
-		logger.Log.Infof("Found %d dead shards", len(deadShards))
-		for _, shard := range deadShards {
-			logger.Log.Infof("Marking shard %d (instance %s) as inactive (last heartbeat: %s)",
-				shard.ShardID, shard.InstanceID, shard.LastHeartbeat)
+		logger.Log.Infof("Found %d dead shards, marking as inactive", len(deadShards))
 
-			if err := database.DB.Model(&models.ShardInfo{}).
-				Where("instance_id = ?", shard.InstanceID).
-				Update("status", "inactive").Error; err != nil {
-				logger.Log.WithError(err).Error("Failed to mark shard as inactive")
-			}
+		var instanceIDs []string
+		for _, shard := range deadShards {
+			instanceIDs = append(instanceIDs, shard.InstanceID)
+			logger.Log.Infof("Marking shard %d (instance %s, host %s, PID %d) as inactive (last heartbeat: %s)",
+				shard.ShardID, shard.InstanceID, shard.Hostname, shard.ProcessID, shard.LastHeartbeat)
 		}
 
-		var activeShardCount int64
 		if err := database.DB.Model(&models.ShardInfo{}).
-			Where("status = 'active'").Count(&activeShardCount).Error; err != nil {
-			logger.Log.WithError(err).Error("Failed to count active shards")
+			Where("instance_id IN ?", instanceIDs).
+			Update("status", "inactive").Error; err != nil {
+			logger.Log.WithError(err).Error("Failed to mark dead shards as inactive")
+		}
+	}
+}
+
+func (asm *AppShardManager) rebalanceShards() {
+	var activeShards []models.ShardInfo
+	if err := database.DB.Where("status = 'active'").
+		Order("shard_id ASC").Find(&activeShards).Error; err != nil {
+		logger.Log.WithError(err).Error("Failed to query active shards for rebalancing")
+		return
+	}
+
+	if len(activeShards) == 0 {
+		logger.Log.Error("No active shards found during rebalancing")
+		return
+	}
+
+	needsRebalance := false
+	newTotalShards := len(activeShards)
+
+	for i, shard := range activeShards {
+		if shard.ShardID != i || shard.TotalShards != newTotalShards {
+			needsRebalance = true
+			break
+		}
+	}
+
+	if !needsRebalance {
+		if asm.TotalShards != newTotalShards {
+			asm.Lock()
+			asm.TotalShards = newTotalShards
+			asm.Unlock()
+			logger.Log.Infof("Updated local total shards to %d", newTotalShards)
+		}
+		return
+	}
+
+	logger.Log.Infof("Rebalancing %d active shards", len(activeShards))
+
+	tx := database.DB.Begin()
+	defer func() {
+		if r := recover(); r != nil {
+			tx.Rollback()
+			logger.Log.Errorf("Panic during shard rebalancing: %v", r)
+		}
+	}()
+
+	for i, shard := range activeShards {
+		newShardID := i
+		if err := tx.Model(&models.ShardInfo{}).
+			Where("instance_id = ?", shard.InstanceID).
+			Updates(map[string]interface{}{
+				"shard_id":     newShardID,
+				"total_shards": newTotalShards,
+			}).Error; err != nil {
+			tx.Rollback()
+			logger.Log.WithError(err).Error("Failed to update shard during rebalancing")
 			return
 		}
 
-		if activeShardCount > 0 {
-			if err := database.DB.Model(&models.ShardInfo{}).
-				Where("status = 'active'").
-				Update("total_shards", activeShardCount).Error; err != nil {
-				logger.Log.WithError(err).Error("Failed to update total shards count")
-			}
-
+		if shard.InstanceID == asm.InstanceID {
 			asm.Lock()
-			asm.TotalShards = int(activeShardCount)
+			asm.ShardID = newShardID
+			asm.TotalShards = newTotalShards
 			asm.Unlock()
-
-			logger.Log.Infof("Updated total active shards to %d", activeShardCount)
+			logger.Log.Infof("Updated local shard assignment to %d of %d", newShardID, newTotalShards)
 		}
+	}
+
+	if err := tx.Commit().Error; err != nil {
+		logger.Log.WithError(err).Error("Failed to commit shard rebalancing transaction")
+		return
+	}
+
+	logger.Log.Infof("Successfully rebalanced shards: total active shards = %d", newTotalShards)
+}
+
+func (asm *AppShardManager) electLeader() {
+	var leader models.ShardInfo
+	if err := database.DB.Where("status = 'active'").
+		Order("startup_time ASC, instance_id ASC").
+		First(&leader).Error; err != nil {
+		logger.Log.WithError(err).Error("Failed to elect leader")
+		return
+	}
+
+	asm.Lock()
+	wasLeader := asm.isLeader
+	asm.isLeader = (leader.InstanceID == asm.InstanceID)
+	asm.Unlock()
+
+	if asm.isLeader && !wasLeader {
+		logger.Log.Infof("Elected as cluster leader (instance %s)", asm.InstanceID)
+	} else if !asm.isLeader && wasLeader {
+		logger.Log.Infof("No longer cluster leader, new leader is %s", leader.InstanceID)
+	}
+}
+
+func (asm *AppShardManager) IsLeader() bool {
+	asm.RLock()
+	defer asm.RUnlock()
+	return asm.isLeader
+}
+
+func (asm *AppShardManager) cleanup() {
+	asm.Lock()
+	defer asm.Unlock()
+
+	if err := database.DB.Model(&models.ShardInfo{}).
+		Where("instance_id = ?", asm.InstanceID).
+		Update("status", "shutdown").Error; err != nil {
+		logger.Log.WithError(err).Error("Failed to mark shard as shutdown")
+	} else {
+		logger.Log.Info("Marked shard as shutdown in database")
 	}
 }
 
@@ -272,14 +450,9 @@ func generateInstanceID() string {
 	}
 
 	pid := os.Getpid()
+	timestamp := time.Now().UnixNano()
 
-	randBytes := make([]byte, 4)
-	for i := range randBytes {
-		randBytes[i] = byte(time.Now().Nanosecond() & 0xff)
-		time.Sleep(time.Nanosecond)
-	}
-
-	return fmt.Sprintf("%s-%d-%x", hostname, pid, randBytes)
+	return fmt.Sprintf("%s-%d-%d", hostname, pid, timestamp)
 }
 
 func (asm *AppShardManager) GetShardingStatus() map[string]interface{} {
@@ -291,6 +464,7 @@ func (asm *AppShardManager) GetShardingStatus() map[string]interface{} {
 		"total_shards":   asm.TotalShards,
 		"instance_id":    asm.InstanceID,
 		"initialized":    asm.Initialized,
+		"is_leader":      asm.isLeader,
 		"last_heartbeat": asm.HeartbeatTime,
 	}
 }

--- a/services/cleanup_users.go
+++ b/services/cleanup_users.go
@@ -64,6 +64,10 @@ func CleanupInactiveUsers() {
 		processedCount, archivedCount, errorCount)
 
 	cleanupOldUnreachableUsers(cfg)
+
+	if err := CleanupOldShadowbanPeriods(365); err != nil {
+		logger.Log.WithError(err).Error("Failed to cleanup old shadowban period data")
+	}
 }
 
 func cleanupOldUnreachableUsers(cfg *configuration.Config) {

--- a/services/cleanup_users.go
+++ b/services/cleanup_users.go
@@ -10,20 +10,231 @@ import (
 )
 
 func CleanupInactiveUsers() {
+	shardMgr := GetAppShardManager()
+	if !shardMgr.IsLeader() {
+		logger.Log.Debug("Skipping user cleanup - not leader shard")
+		return
+	}
+
 	cfg := configuration.Get()
 	inactivePeriod := time.Now().Add(-cfg.Users.InactiveUserPeriod)
 
-	var inactiveUsers []models.UserSettings
+	logger.Log.Info("Starting inactive user cleanup process")
+
+	var allInactiveUsers []models.UserSettings
 	if err := database.DB.Where("last_guild_interaction < ? AND last_direct_interaction < ?",
-		inactivePeriod, inactivePeriod).Find(&inactiveUsers).Error; err != nil {
+		inactivePeriod, inactivePeriod).Find(&allInactiveUsers).Error; err != nil {
 		logger.Log.WithError(err).Error("Failed to fetch inactive users")
 		return
 	}
 
-	logger.Log.Infof("Found %d inactive users to archive", len(inactiveUsers))
+	logger.Log.Infof("Found %d potentially inactive users to process", len(allInactiveUsers))
 
-	for _, user := range inactiveUsers {
+	processedCount := 0
+	archivedCount := 0
+	errorCount := 0
+
+	for _, user := range allInactiveUsers {
+		if user.UserID == "" {
+			logger.Log.Warn("Skipping user with empty UserID")
+			errorCount++
+			continue
+		}
+
 		user.IsUnreachable = true
-		database.DB.Save(&user)
+		if user.UnreachableSince.IsZero() {
+			user.UnreachableSince = time.Now()
+		}
+
+		if err := database.DB.Save(&user).Error; err != nil {
+			logger.Log.WithError(err).Errorf("Failed to mark user %s as unreachable", user.UserID)
+			errorCount++
+			continue
+		}
+
+		archivedCount++
+		processedCount++
+
+		if processedCount%100 == 0 {
+			logger.Log.Infof("Processed %d inactive users so far", processedCount)
+		}
 	}
+
+	logger.Log.Infof("Completed inactive user cleanup: processed %d users, archived %d as unreachable, %d errors",
+		processedCount, archivedCount, errorCount)
+
+	cleanupOldUnreachableUsers(cfg)
+}
+
+func cleanupOldUnreachableUsers(cfg *configuration.Config) {
+	cutoffTime := time.Now().Add(-cfg.Users.UnreachableResetPeriod)
+
+	var oldUnreachableCount int64
+	if err := database.DB.Model(&models.UserSettings{}).
+		Where("is_unreachable = ? AND unreachable_since < ?", true, cutoffTime).
+		Count(&oldUnreachableCount).Error; err != nil {
+		logger.Log.WithError(err).Error("Failed to count old unreachable users")
+		return
+	}
+
+	if oldUnreachableCount == 0 {
+		logger.Log.Debug("No old unreachable users to reset")
+		return
+	}
+
+	logger.Log.Infof("Resetting %d users that have been unreachable for more than %v",
+		oldUnreachableCount, cfg.Users.UnreachableResetPeriod)
+
+	result := database.DB.Model(&models.UserSettings{}).
+		Where("is_unreachable = ? AND unreachable_since < ?", true, cutoffTime).
+		Updates(map[string]interface{}{
+			"is_unreachable":       false,
+			"unreachable_since":    time.Time{},
+			"message_failures":     0,
+			"last_message_failure": time.Time{},
+		})
+
+	if result.Error != nil {
+		logger.Log.WithError(result.Error).Error("Failed to reset old unreachable users")
+	} else {
+		logger.Log.Infof("Successfully reset %d old unreachable users", result.RowsAffected)
+	}
+}
+
+func CleanupUsersByShardAssignment() {
+	shardMgr := GetAppShardManager()
+	if !shardMgr.IsLeader() {
+		logger.Log.Debug("Skipping shard assignment cleanup - not leader shard")
+		return
+	}
+
+	logger.Log.Info("Starting shard assignment cleanup")
+
+	var activeShards []models.ShardInfo
+	if err := database.DB.Where("status = 'active'").Find(&activeShards).Error; err != nil {
+		logger.Log.WithError(err).Error("Failed to get active shards for cleanup")
+		return
+	}
+
+	if len(activeShards) == 0 {
+		logger.Log.Warn("No active shards found during cleanup")
+		return
+	}
+
+	totalShards := len(activeShards)
+	logger.Log.Infof("Validating user assignments against %d active shards", totalShards)
+
+	var allUsers []models.UserSettings
+	if err := database.DB.Select("user_id").Find(&allUsers).Error; err != nil {
+		logger.Log.WithError(err).Error("Failed to get users for shard assignment cleanup")
+		return
+	}
+
+	orphanedUsers := 0
+	processedUsers := 0
+
+	for _, user := range allUsers {
+		if user.UserID == "" {
+			continue
+		}
+
+		userShard := getUserShard(user.UserID, totalShards)
+
+		shardExists := false
+		for _, activeShard := range activeShards {
+			if activeShard.ShardID == userShard {
+				shardExists = true
+				break
+			}
+		}
+
+		if !shardExists {
+			logger.Log.Debugf("User %s assigned to non-existent shard %d (total: %d)",
+				user.UserID, userShard, totalShards)
+			orphanedUsers++
+		}
+
+		processedUsers++
+	}
+
+	logger.Log.Infof("Shard assignment cleanup complete: processed %d users, found %d orphaned users",
+		processedUsers, orphanedUsers)
+
+	if orphanedUsers > 0 {
+		logger.Log.Warnf("Found %d users assigned to non-existent shards - they may not be processed until shard rebalancing occurs", orphanedUsers)
+	}
+}
+
+func CleanupOldShardInfo() {
+	shardMgr := GetAppShardManager()
+	if !shardMgr.IsLeader() {
+		logger.Log.Debug("Skipping shard info cleanup - not leader shard")
+		return
+	}
+
+	cutoffTime := time.Now().Add(-24 * time.Hour)
+
+	var oldShardCount int64
+	if err := database.DB.Model(&models.ShardInfo{}).
+		Where("status != 'active' AND last_heartbeat < ?", cutoffTime).
+		Count(&oldShardCount).Error; err != nil {
+		logger.Log.WithError(err).Error("Failed to count old shard records")
+		return
+	}
+
+	if oldShardCount == 0 {
+		logger.Log.Debug("No old shard records to clean up")
+		return
+	}
+
+	logger.Log.Infof("Cleaning up %d old shard info records", oldShardCount)
+
+	result := database.DB.Where("status != 'active' AND last_heartbeat < ?", cutoffTime).
+		Delete(&models.ShardInfo{})
+
+	if result.Error != nil {
+		logger.Log.WithError(result.Error).Error("Failed to clean up old shard records")
+	} else {
+		logger.Log.Infof("Successfully cleaned up %d old shard records", result.RowsAffected)
+	}
+}
+
+func ValidateUserShardAssignments() (map[string]interface{}, error) {
+	shardMgr := GetAppShardManager()
+
+	stats := map[string]interface{}{
+		"total_users":        0,
+		"valid_users":        0,
+		"invalid_users":      0,
+		"empty_userids":      0,
+		"shard_distribution": make(map[int]int),
+	}
+
+	var users []models.UserSettings
+	if err := database.DB.Select("user_id").Find(&users).Error; err != nil {
+		return stats, err
+	}
+
+	stats["total_users"] = len(users)
+
+	for _, user := range users {
+		if user.UserID == "" {
+			stats["empty_userids"] = stats["empty_userids"].(int) + 1
+			continue
+		}
+
+		userShard := getUserShard(user.UserID, shardMgr.TotalShards)
+
+		distribution := stats["shard_distribution"].(map[int]int)
+		distribution[userShard]++
+		stats["shard_distribution"] = distribution
+
+		if userShard >= 0 && userShard < shardMgr.TotalShards {
+			stats["valid_users"] = stats["valid_users"].(int) + 1
+		} else {
+			stats["invalid_users"] = stats["invalid_users"].(int) + 1
+		}
+	}
+
+	return stats, nil
 }

--- a/services/context-tracking.go
+++ b/services/context-tracking.go
@@ -162,35 +162,41 @@ func GetInstallationStats() (serverCount int64, directCount int64, err error) {
 	return
 }
 
-func LogInstallationStats(s *discordgo.Session) {
-	var stats struct {
-		TotalUsers     int64
-		ActiveUsers    int64
-		TotalAccounts  int64
-		ActiveAccounts int64
-		TotalGuilds    int64
-		UserInstalls   int64
-		GuildInstalls  int64
+func LogInstallationStats(s interface{}) {
+	shardMgr := GetAppShardManager()
+	if !shardMgr.IsLeader() {
+		return
 	}
 
-	database.DB.Model(&models.UserSettings{}).Count(&stats.TotalUsers)
-	database.DB.Model(&models.UserSettings{}).Where("updated_at > ?", time.Now().Add(-7*24*time.Hour)).Count(&stats.ActiveUsers)
-	database.DB.Model(&models.Account{}).Count(&stats.TotalAccounts)
-	database.DB.Model(&models.Account{}).Where("is_check_disabled = ? AND is_expired_cookie = ?", false, false).Count(&stats.ActiveAccounts)
-	database.DB.Model(&models.UserSettings{}).Where("installation_type = ?", "direct").Count(&stats.UserInstalls)
-	database.DB.Model(&models.UserSettings{}).Where("installation_type = ?", "server").Count(&stats.GuildInstalls)
+	var serverInstalls int64
+	var directInstalls int64
+	var totalUsers int64
 
-	distinctGuilds := make(map[string]bool)
-	var userSettings []models.UserSettings
-	if err := database.DB.Select("installation_guild_id").Where("installation_guild_id != ''").Find(&userSettings).Error; err == nil {
-		for _, us := range userSettings {
-			if us.InstallationGuildID != "" {
-				distinctGuilds[us.InstallationGuildID] = true
-			}
-		}
+	if err := database.DB.Model(&models.UserSettings{}).Count(&totalUsers).Error; err != nil {
+		logger.Log.WithError(err).Error("Failed to count total users for installation stats")
+		return
 	}
-	stats.TotalGuilds = int64(len(distinctGuilds))
 
-	logger.Log.Infof("Installation Stats - Total Users: %d, Active Users (7d): %d, Total Accounts: %d, Active Accounts: %d, Total Guilds: %d, User Installs: %d, Guild Installs: %d",
-		stats.TotalUsers, stats.ActiveUsers, stats.TotalAccounts, stats.ActiveAccounts, stats.TotalGuilds, stats.UserInstalls, stats.GuildInstalls)
+	if err := database.DB.Model(&models.UserSettings{}).
+		Where("installation_type = ?", "server").Count(&serverInstalls).Error; err != nil {
+		logger.Log.WithError(err).Error("Failed to count server installations")
+	}
+
+	if err := database.DB.Model(&models.UserSettings{}).
+		Where("installation_type = ?", "direct").Count(&directInstalls).Error; err != nil {
+		logger.Log.WithError(err).Error("Failed to count direct installations")
+	}
+
+	metadata := map[string]interface{}{
+		"total_users":     totalUsers,
+		"server_installs": serverInstalls,
+		"direct_installs": directInstalls,
+		"stats_type":      "daily_installation_summary",
+	}
+
+	LogAnalyticsEvent("installation_stats", "", "", "", "info",
+		shardMgr.ShardID, shardMgr.InstanceID, metadata)
+
+	logger.Log.Infof("Logged installation stats: Total: %d, Server: %d, Direct: %d",
+		totalUsers, serverInstalls, directInstalls)
 }

--- a/services/http.go
+++ b/services/http.go
@@ -380,8 +380,15 @@ func CheckAccount(ssoCookie string, userID string, captchaAPIKey string) (models
 		logger.Log.WithError(err).Error("Failed to update account with game-specific bans")
 	}
 
-	LogAccountCheck(accountID, userID, "", err == nil,
-		captchaProvider, captchaCost, time.Since(startTime).Milliseconds())
+	LogAccountCheck(accountID, userID, err == nil, overallStatus,
+		time.Since(startTime).Milliseconds(), captchaProvider, captchaCost,
+		func() string {
+			if err != nil {
+				return err.Error()
+			} else {
+				return ""
+			}
+		}())
 
 	if accountID > 0 {
 		LogAccountStatusCheck(accountID, userID, overallStatus, "manual_check", "")

--- a/services/mainfunction.go
+++ b/services/mainfunction.go
@@ -429,11 +429,17 @@ func HandleStatusChange(s *discordgo.Session, account models.Account, newStatus 
 			ban.AffectedGames = statusLog.AffectedGames
 		}
 
+		var banID uint
 		if err := database.DB.Create(&ban).Error; err != nil {
 			logger.Log.WithError(err).Error("Failed to create ban record")
 		} else {
+			banID = ban.ID
 			logger.Log.Infof("Shard %d - Created ban record for account %s: %s -> %s",
 				shardMgr.ShardID, account.Title, previousStatus, newStatus)
+		}
+
+		if err := TrackShadowbanTransition(account.ID, account.UserID, previousStatus, newStatus, banID); err != nil {
+			logger.Log.WithError(err).Error("Failed to track shadowban transition")
 		}
 
 		LogStatusChange(account.ID, account.UserID, newStatus, previousStatus)

--- a/services/mainfunction.go
+++ b/services/mainfunction.go
@@ -37,12 +37,8 @@ func InitializeServices() {
 func CheckAccounts(s *discordgo.Session) {
 	logger.Log.Info("Starting periodic account check")
 	shardMgr := GetAppShardManager()
-	if !shardMgr.Initialized {
-		if err := shardMgr.Initialize(); err != nil {
-			logger.Log.WithError(err).Error("Failed to initialize app shard manager")
-			return
-		}
-	}
+
+	shardMgr.EnsureInitialized()
 
 	shardMgr.RLock()
 	shardID := shardMgr.ShardID
@@ -74,8 +70,15 @@ func CheckAccounts(s *discordgo.Session) {
 		return
 	}
 
-	accounts = FilterAccountsByShardAssignment(accounts)
-	shardAccounts = int64(len(accounts))
+	cfg := configuration.Get()
+	if cfg.Sharding.Enabled && shardMgr.Initialized && shardMgr.TotalShards > 1 {
+		accounts = FilterAccountsByShardAssignment(accounts)
+		shardAccounts = int64(len(accounts))
+		logger.Log.Infof("Sharding enabled - filtering %d accounts to %d for shard %d", int(totalAccounts), len(accounts), shardMgr.ShardID)
+	} else {
+		shardAccounts = int64(len(accounts))
+		logger.Log.Infof("Sharding disabled or failed - processing all %d accounts", len(accounts))
+	}
 
 	logger.Log.Infof("Shard %d/%d - Account status summary: Total Global: %d, Shard Assigned: %d, Disabled: %d, Expired Cookies: %d",
 		shardID, totalShards, totalAccounts, shardAccounts, disabledAccounts, expiredCookieAccounts)
@@ -90,10 +93,12 @@ func CheckAccounts(s *discordgo.Session) {
 			continue
 		}
 
-		if !shardMgr.IsUserAssignedToShard(account.UserID) {
-			logger.Log.Debugf("Account %s (user %s) not assigned to this shard, skipping", account.Title, account.UserID)
-			skippedAccounts++
-			continue
+		if cfg.Sharding.Enabled && shardMgr.Initialized && shardMgr.TotalShards > 1 {
+			if !shardMgr.IsUserAssignedToShard(account.UserID) {
+				logger.Log.Debugf("Account %s (user %s) not assigned to this shard, skipping", account.Title, account.UserID)
+				skippedAccounts++
+				continue
+			}
 		}
 
 		accountsByUser[account.UserID] = append(accountsByUser[account.UserID], account)
@@ -105,17 +110,24 @@ func CheckAccounts(s *discordgo.Session) {
 	start := time.Now()
 
 	for userID, userAccounts := range accountsByUser {
-		err := shardMgr.SafeShardOperation(userID, func() error {
+		if cfg.Sharding.Enabled && shardMgr.Initialized && shardMgr.TotalShards > 1 {
+			err := shardMgr.SafeShardOperation(userID, func() error {
+				userSuccess, userFailed := processUserAccountsWithStats(s, userID, userAccounts)
+				successfulChecks += userSuccess
+				failedChecks += userFailed
+				processedCount++
+				return nil
+			})
+
+			if err != nil {
+				logger.Log.WithError(err).Warnf("Skipped processing user %s due to shard assignment validation", userID)
+				skippedAccounts += len(userAccounts)
+			}
+		} else {
 			userSuccess, userFailed := processUserAccountsWithStats(s, userID, userAccounts)
 			successfulChecks += userSuccess
 			failedChecks += userFailed
 			processedCount++
-			return nil
-		})
-
-		if err != nil {
-			logger.Log.WithError(err).Warnf("Skipped processing user %s due to shard assignment validation", userID)
-			skippedAccounts += len(userAccounts)
 		}
 	}
 
@@ -267,19 +279,37 @@ func LogNotification(userID string, accountID uint, notificationType string, suc
 }
 
 func updateShardStats(instanceID string, processedUsers, successfulChecks, failedChecks int, durationSec float64) error {
+	totalChecks := successfulChecks + failedChecks
+
+	var checkRate float64
+	if durationSec > 0 {
+		checkRate = float64(totalChecks) / durationSec
+	} else {
+		checkRate = 0
+	}
+
+	var successRate float64
+	if totalChecks > 0 {
+		successRate = float64(successfulChecks) / float64(totalChecks) * 100
+	} else {
+		successRate = 0
+	}
+
 	stats := map[string]interface{}{
 		"last_check_time":   time.Now(),
 		"processed_users":   processedUsers,
 		"successful_checks": successfulChecks,
 		"failed_checks":     failedChecks,
 		"duration_sec":      durationSec,
-		"check_rate":        float64(successfulChecks+failedChecks) / durationSec,
-		"success_rate":      float64(successfulChecks) / float64(successfulChecks+failedChecks) * 100,
+		"check_rate":        checkRate,
+		"success_rate":      successRate,
 	}
+
 	statJSON, err := json.Marshal(stats)
 	if err != nil {
 		return err
 	}
+
 	return database.DB.Model(&models.ShardInfo{}).
 		Where("instance_id = ?", instanceID).
 		Update("stats", string(statJSON)).Error

--- a/services/mainfunction.go
+++ b/services/mainfunction.go
@@ -44,6 +44,12 @@ func CheckAccounts(s *discordgo.Session) {
 		}
 	}
 
+	shardMgr.RLock()
+	shardID := shardMgr.ShardID
+	totalShards := shardMgr.TotalShards
+	instanceID := shardMgr.InstanceID
+	shardMgr.RUnlock()
+
 	var totalAccounts int64
 	var disabledAccounts int64
 	var expiredCookieAccounts int64
@@ -61,8 +67,8 @@ func CheckAccounts(s *discordgo.Session) {
 		logger.Log.WithError(err).Error("Failed to count expired cookie accounts")
 	}
 
-	logger.Log.Infof("Account status summary: Total: %d, Disabled: %d, Expired Cookies: %d, Eligible for check: %d",
-		totalAccounts, disabledAccounts, expiredCookieAccounts, totalAccounts-disabledAccounts-expiredCookieAccounts)
+	logger.Log.Infof("Shard %d/%d - Account status summary: Total: %d, Disabled: %d, Expired Cookies: %d, Eligible for check: %d",
+		shardID, totalShards, totalAccounts, disabledAccounts, expiredCookieAccounts, totalAccounts-disabledAccounts-expiredCookieAccounts)
 
 	var accounts []models.Account
 	if err := database.DB.Where("is_check_disabled = ? AND is_expired_cookie = ?", false, false).Find(&accounts).Error; err != nil {
@@ -70,12 +76,19 @@ func CheckAccounts(s *discordgo.Session) {
 		return
 	}
 
+	accounts = FilterAccountsByShardAssignment(accounts)
+
 	accountsByUser := make(map[string][]models.Account)
 	for _, account := range accounts {
 		if account.UserID == "" {
 			logger.Log.Warnf("Skipping account %s (ID: %d) with empty UserID", account.Title, account.ID)
 			continue
 		}
+
+		if !shardMgr.IsUserAssignedToShard(account.UserID) {
+			continue
+		}
+
 		accountsByUser[account.UserID] = append(accountsByUser[account.UserID], account)
 	}
 
@@ -86,10 +99,6 @@ func CheckAccounts(s *discordgo.Session) {
 	start := time.Now()
 
 	for userID, userAccounts := range accountsByUser {
-		if !shardMgr.IsUserAssignedToShard(userID) {
-			skippedCount++
-			continue
-		}
 		userSuccess, userFailed := processUserAccountsWithStats(s, userID, userAccounts)
 		successfulChecks += userSuccess
 		failedChecks += userFailed
@@ -97,18 +106,105 @@ func CheckAccounts(s *discordgo.Session) {
 	}
 
 	duration := time.Since(start).Seconds()
-	logger.Log.Infof("Completed periodic account check: processed %d users, skipped %d users, successful checks: %d, failed checks: %d, in %.2f seconds",
-		processedCount, skippedCount, successfulChecks, failedChecks, duration)
+	logger.Log.Infof("Shard %d/%d completed periodic account check: processed %d users, skipped %d users, successful checks: %d, failed checks: %d, in %.2f seconds",
+		shardID, totalShards, processedCount, skippedCount, successfulChecks, failedChecks, duration)
 
-	if err := updateShardStats(shardMgr.InstanceID, processedCount, duration); err != nil {
+	if err := updateShardStats(instanceID, processedCount, successfulChecks, failedChecks, duration); err != nil {
 		logger.Log.WithError(err).Error("Failed to update shard stats")
 	}
+
+	LogAnalyticsEvent("shard_check_completed", "", "", "", "", shardID, instanceID, map[string]interface{}{
+		"processed_users":   processedCount,
+		"successful_checks": successfulChecks,
+		"failed_checks":     failedChecks,
+		"duration_seconds":  duration,
+		"total_accounts":    len(accounts),
+	})
 }
-func updateShardStats(instanceID string, processedUsers int, durationSec float64) error {
+
+func LogAnalyticsEvent(s string, s2 string, s3 string, s4 string, s5 string, id int, id2 string, m map[string]interface{}) {
+
+}
+
+func processUserAccountsWithStats(s *discordgo.Session, userID string, accounts []models.Account) (int, int) {
+	var userSettings models.UserSettings
+	if err := database.DB.Where("user_id = ?", userID).First(&userSettings).Error; err != nil {
+		userSettings = models.UserSettings{
+			UserID:                   userID,
+			CheckInterval:            configuration.Get().Intervals.Check,
+			NotificationInterval:     configuration.Get().Intervals.Notification,
+			CooldownDuration:         configuration.Get().Intervals.Cooldown,
+			StatusChangeCooldown:     configuration.Get().Intervals.StatusChange,
+			PreferredCaptchaProvider: "capsolver",
+			NotificationType:         "channel",
+			PreferEphemeralResponses: true,
+			EnableFallback:           true,
+			UseFallbackForDefault:    true,
+		}
+		userSettings.EnsureMapsInitialized()
+		if err := database.DB.Create(&userSettings).Error; err != nil {
+			logger.Log.WithError(err).Errorf("Failed to create user settings for %s", userID)
+			return 0, len(accounts)
+		}
+	}
+
+	successCount := 0
+	failCount := 0
+
+	for _, account := range accounts {
+		if time.Since(time.Unix(account.LastCheck, 0)) < time.Duration(userSettings.CheckInterval)*time.Minute {
+			continue
+		}
+
+		if account.ConsecutiveErrors >= configuration.Get().ErrorHandling.MaxConsecutiveErrors {
+			if !account.IsCheckDisabled {
+				disableAccount(s, account, fmt.Sprintf("Too many consecutive errors (%d)", account.ConsecutiveErrors))
+			}
+			failCount++
+			continue
+		}
+
+		result, err := CheckAccountWithRetry(account.SSOCookie, userID, "")
+		if err != nil {
+			logger.Log.WithError(err).Errorf("Failed to check account %s for user %s", account.Title, userID)
+
+			account.ConsecutiveErrors++
+			account.LastErrorTime = time.Now()
+			if err := database.DB.Save(&account).Error; err != nil {
+				logger.Log.WithError(err).Error("Failed to update account error count")
+			}
+
+			failCount++
+			continue
+		}
+
+		account.LastCheck = time.Now().Unix()
+		account.ConsecutiveErrors = 0
+		account.LastSuccessfulCheck = time.Now()
+
+		if account.LastStatus != result {
+			HandleStatusChange(s, account, result, &userSettings)
+		} else {
+			if err := database.DB.Save(&account).Error; err != nil {
+				logger.Log.WithError(err).Error("Failed to update account check time")
+			}
+		}
+
+		successCount++
+	}
+
+	return successCount, failCount
+}
+
+func updateShardStats(instanceID string, processedUsers, successfulChecks, failedChecks int, durationSec float64) error {
 	stats := map[string]interface{}{
-		"last_check_time": time.Now(),
-		"processed_users": processedUsers,
-		"duration_sec":    durationSec,
+		"last_check_time":   time.Now(),
+		"processed_users":   processedUsers,
+		"successful_checks": successfulChecks,
+		"failed_checks":     failedChecks,
+		"duration_sec":      durationSec,
+		"check_rate":        float64(successfulChecks+failedChecks) / durationSec,
+		"success_rate":      float64(successfulChecks) / float64(successfulChecks+failedChecks) * 100,
 	}
 	statJSON, err := json.Marshal(stats)
 	if err != nil {
@@ -119,7 +215,35 @@ func updateShardStats(instanceID string, processedUsers int, durationSec float64
 		Update("stats", string(statJSON)).Error
 }
 
+func CheckAccountWithRetry(ssoCookie, userID, captchaProvider string) (models.Status, error) {
+	maxRetries := 3
+	baseDelay := time.Second
+
+	for attempt := 0; attempt < maxRetries; attempt++ {
+		if attempt > 0 {
+			delay := baseDelay * time.Duration(1<<uint(attempt-1))
+			logger.Log.Debugf("Retrying account check for user %s in %v (attempt %d/%d)", userID, delay, attempt+1, maxRetries)
+			time.Sleep(delay)
+		}
+
+		result, err := CheckAccount(ssoCookie, userID, captchaProvider)
+		if err == nil {
+			return result, nil
+		}
+
+		if attempt == maxRetries-1 {
+			return models.StatusUnknown, err
+		}
+
+		logger.Log.WithError(err).Warnf("Account check attempt %d/%d failed for user %s", attempt+1, maxRetries, userID)
+	}
+
+	return models.StatusUnknown, fmt.Errorf("all retry attempts failed")
+}
+
 func HandleStatusChange(s *discordgo.Session, account models.Account, newStatus models.Status, userSettings *models.UserSettings) {
+	shardMgr := GetAppShardManager()
+
 	if account.IsPermabanned && newStatus == models.StatusPermaban {
 		if account.LastNotification != 0 {
 			logger.Log.Debugf("Account %s already notified of permaban, skipping notification", account.Title)
@@ -139,8 +263,8 @@ func HandleStatusChange(s *discordgo.Session, account models.Account, newStatus 
 	}
 
 	if statusChanged || gameSpecificChanged {
-		logger.Log.Debugf("Status change detected for account %s: %s -> %s (Game-specific changes: %v)",
-			account.Title, account.LastStatus, newStatus, gameSpecificChanged)
+		logger.Log.Debugf("Shard %d - Status change detected for account %s: %s -> %s (Game-specific changes: %v)",
+			shardMgr.ShardID, account.Title, account.LastStatus, newStatus, gameSpecificChanged)
 
 		DBMutex.Lock()
 		defer DBMutex.Unlock()
@@ -188,7 +312,8 @@ func HandleStatusChange(s *discordgo.Session, account models.Account, newStatus 
 		if err := database.DB.Create(&statusLog).Error; err != nil {
 			logger.Log.WithError(err).Error("Failed to create status log")
 		} else {
-			logger.Log.Infof("Created status change log for account %s: %s -> %s", account.Title, previousStatus, newStatus)
+			logger.Log.Infof("Shard %d - Created status change log for account %s: %s -> %s",
+				shardMgr.ShardID, account.Title, previousStatus, newStatus)
 		}
 
 		ban := models.Ban{
@@ -207,7 +332,8 @@ func HandleStatusChange(s *discordgo.Session, account models.Account, newStatus 
 		if err := database.DB.Create(&ban).Error; err != nil {
 			logger.Log.WithError(err).Error("Failed to create ban record")
 		} else {
-			logger.Log.Infof("Created ban record for account %s: %s -> %s", account.Title, previousStatus, newStatus)
+			logger.Log.Infof("Shard %d - Created ban record for account %s: %s -> %s",
+				shardMgr.ShardID, account.Title, previousStatus, newStatus)
 		}
 
 		LogStatusChange(account.ID, account.UserID, newStatus, previousStatus)
@@ -237,6 +363,13 @@ func HandleStatusChange(s *discordgo.Session, account models.Account, newStatus 
 		if err := database.DB.Save(&account).Error; err != nil {
 			logger.Log.WithError(err).Error("Failed to save final account status")
 		}
+
+		LogAnalyticsEvent("status_change", account.UserID, "", "", string(newStatus), shardMgr.ShardID, shardMgr.InstanceID, map[string]interface{}{
+			"account_id":      account.ID,
+			"previous_status": string(previousStatus),
+			"new_status":      string(newStatus),
+			"account_title":   account.Title,
+		})
 	}
 }
 
@@ -543,7 +676,8 @@ func disableAccount(s *discordgo.Session, account models.Account, reason string)
 		return
 	}
 
-	logger.Log.Infof("Account %s has been disabled. Reason: %s", account.Title, reason)
+	shardMgr := GetAppShardManager()
+	logger.Log.Infof("Shard %d - Account %s has been disabled. Reason: %s", shardMgr.ShardID, account.Title, reason)
 	NotifyUserAboutDisabledAccount(s, account, reason)
 }
 

--- a/services/mainfunction.go
+++ b/services/mainfunction.go
@@ -53,6 +53,7 @@ func CheckAccounts(s *discordgo.Session) {
 	var totalAccounts int64
 	var disabledAccounts int64
 	var expiredCookieAccounts int64
+	var shardAccounts int64
 
 	if err := database.DB.Model(&models.Account{}).Count(&totalAccounts).Error; err != nil {
 		logger.Log.WithError(err).Error("Failed to count total accounts")
@@ -67,9 +68,6 @@ func CheckAccounts(s *discordgo.Session) {
 		logger.Log.WithError(err).Error("Failed to count expired cookie accounts")
 	}
 
-	logger.Log.Infof("Shard %d/%d - Account status summary: Total: %d, Disabled: %d, Expired Cookies: %d, Eligible for check: %d",
-		shardID, totalShards, totalAccounts, disabledAccounts, expiredCookieAccounts, totalAccounts-disabledAccounts-expiredCookieAccounts)
-
 	var accounts []models.Account
 	if err := database.DB.Where("is_check_disabled = ? AND is_expired_cookie = ?", false, false).Find(&accounts).Error; err != nil {
 		logger.Log.WithError(err).Error("Failed to fetch accounts from database")
@@ -77,15 +75,24 @@ func CheckAccounts(s *discordgo.Session) {
 	}
 
 	accounts = FilterAccountsByShardAssignment(accounts)
+	shardAccounts = int64(len(accounts))
+
+	logger.Log.Infof("Shard %d/%d - Account status summary: Total Global: %d, Shard Assigned: %d, Disabled: %d, Expired Cookies: %d",
+		shardID, totalShards, totalAccounts, shardAccounts, disabledAccounts, expiredCookieAccounts)
 
 	accountsByUser := make(map[string][]models.Account)
+	skippedAccounts := 0
+
 	for _, account := range accounts {
 		if account.UserID == "" {
 			logger.Log.Warnf("Skipping account %s (ID: %d) with empty UserID", account.Title, account.ID)
+			skippedAccounts++
 			continue
 		}
 
 		if !shardMgr.IsUserAssignedToShard(account.UserID) {
+			logger.Log.Debugf("Account %s (user %s) not assigned to this shard, skipping", account.Title, account.UserID)
+			skippedAccounts++
 			continue
 		}
 
@@ -93,107 +100,170 @@ func CheckAccounts(s *discordgo.Session) {
 	}
 
 	processedCount := 0
-	skippedCount := 0
 	successfulChecks := 0
 	failedChecks := 0
 	start := time.Now()
 
 	for userID, userAccounts := range accountsByUser {
-		userSuccess, userFailed := processUserAccountsWithStats(s, userID, userAccounts)
-		successfulChecks += userSuccess
-		failedChecks += userFailed
-		processedCount++
+		err := shardMgr.SafeShardOperation(userID, func() error {
+			userSuccess, userFailed := processUserAccountsWithStats(s, userID, userAccounts)
+			successfulChecks += userSuccess
+			failedChecks += userFailed
+			processedCount++
+			return nil
+		})
+
+		if err != nil {
+			logger.Log.WithError(err).Warnf("Skipped processing user %s due to shard assignment validation", userID)
+			skippedAccounts += len(userAccounts)
+		}
 	}
 
 	duration := time.Since(start).Seconds()
-	logger.Log.Infof("Shard %d/%d completed periodic account check: processed %d users, skipped %d users, successful checks: %d, failed checks: %d, in %.2f seconds",
-		shardID, totalShards, processedCount, skippedCount, successfulChecks, failedChecks, duration)
+	logger.Log.Infof("Shard %d/%d completed periodic account check: processed %d users (%d accounts), skipped %d accounts, successful checks: %d, failed checks: %d, in %.2f seconds",
+		shardID, totalShards, processedCount, len(accounts)-skippedAccounts, skippedAccounts, successfulChecks, failedChecks, duration)
 
 	if err := updateShardStats(instanceID, processedCount, successfulChecks, failedChecks, duration); err != nil {
 		logger.Log.WithError(err).Error("Failed to update shard stats")
 	}
 
 	LogAnalyticsEvent("shard_check_completed", "", "", "", "", shardID, instanceID, map[string]interface{}{
-		"processed_users":   processedCount,
-		"successful_checks": successfulChecks,
-		"failed_checks":     failedChecks,
-		"duration_seconds":  duration,
-		"total_accounts":    len(accounts),
+		"processed_users":       processedCount,
+		"successful_checks":     successfulChecks,
+		"failed_checks":         failedChecks,
+		"duration_seconds":      duration,
+		"shard_accounts":        shardAccounts,
+		"skipped_accounts":      skippedAccounts,
+		"total_global_accounts": totalAccounts,
 	})
 }
 
-func LogAnalyticsEvent(s string, s2 string, s3 string, s4 string, s5 string, id int, id2 string, m map[string]interface{}) {
+func LogAnalyticsEvent(eventType, userID, guildID, commandName, status string, shardID int, instanceID string, metadata map[string]interface{}) {
+	if eventType == "" {
+		logger.Log.Error("Analytics event type cannot be empty")
+		return
+	}
 
+	analytics := models.Analytics{
+		Type:        eventType,
+		UserID:      userID,
+		GuildID:     guildID,
+		CommandName: commandName,
+		Status:      status,
+		ShardID:     shardID,
+		InstanceID:  instanceID,
+		Timestamp:   time.Now(),
+		Day:         time.Now().Format("2006-01-02"),
+		Success:     true,
+	}
+
+	if metadata != nil {
+		if success, ok := metadata["success"].(bool); ok {
+			analytics.Success = success
+		}
+		if responseTime, ok := metadata["response_time_ms"].(int64); ok {
+			analytics.ResponseTimeMs = responseTime
+		}
+		if captchaProvider, ok := metadata["captcha_provider"].(string); ok {
+			analytics.CaptchaProvider = captchaProvider
+		}
+		if captchaCost, ok := metadata["captcha_cost"].(float64); ok {
+			analytics.CaptchaCost = captchaCost
+		}
+		if errorDetails, ok := metadata["error_details"].(string); ok {
+			analytics.ErrorDetails = errorDetails
+		}
+		if previousStatus, ok := metadata["previous_status"].(string); ok {
+			analytics.PreviousStatus = previousStatus
+		}
+		if accountID, ok := metadata["account_id"].(uint); ok {
+			analytics.AccountID = accountID
+		}
+	}
+
+	if err := database.DB.Create(&analytics).Error; err != nil {
+		logger.Log.WithError(err).WithField("event_type", eventType).
+			WithField("shard_id", shardID).
+			WithField("instance_id", instanceID).
+			Error("Failed to log analytics event")
+	} else {
+		logger.Log.Debugf("Logged analytics event: %s (shard %d, instance %s)", eventType, shardID, instanceID)
+	}
 }
 
-func processUserAccountsWithStats(s *discordgo.Session, userID string, accounts []models.Account) (int, int) {
-	var userSettings models.UserSettings
-	if err := database.DB.Where("user_id = ?", userID).First(&userSettings).Error; err != nil {
-		userSettings = models.UserSettings{
-			UserID:                   userID,
-			CheckInterval:            configuration.Get().Intervals.Check,
-			NotificationInterval:     configuration.Get().Intervals.Notification,
-			CooldownDuration:         configuration.Get().Intervals.Cooldown,
-			StatusChangeCooldown:     configuration.Get().Intervals.StatusChange,
-			PreferredCaptchaProvider: "capsolver",
-			NotificationType:         "channel",
-			PreferEphemeralResponses: true,
-			EnableFallback:           true,
-			UseFallbackForDefault:    true,
-		}
-		userSettings.EnsureMapsInitialized()
-		if err := database.DB.Create(&userSettings).Error; err != nil {
-			logger.Log.WithError(err).Errorf("Failed to create user settings for %s", userID)
-			return 0, len(accounts)
-		}
+func LogStatusChange(accountID uint, userID string, newStatus, previousStatus models.Status) {
+	shardMgr := GetAppShardManager()
+
+	metadata := map[string]interface{}{
+		"account_id":      accountID,
+		"previous_status": string(previousStatus),
+		"new_status":      string(newStatus),
+		"status_changed":  previousStatus != newStatus,
 	}
 
-	successCount := 0
-	failCount := 0
+	LogAnalyticsEvent("status_change", userID, "", "", string(newStatus),
+		shardMgr.ShardID, shardMgr.InstanceID, metadata)
+}
 
-	for _, account := range accounts {
-		if time.Since(time.Unix(account.LastCheck, 0)) < time.Duration(userSettings.CheckInterval)*time.Minute {
-			continue
-		}
+func LogAccountCheck(accountID uint, userID string, success bool, status models.Status, responseTimeMs int64, captchaProvider string, captchaCost float64, errorDetails string) {
+	shardMgr := GetAppShardManager()
 
-		if account.ConsecutiveErrors >= configuration.Get().ErrorHandling.MaxConsecutiveErrors {
-			if !account.IsCheckDisabled {
-				disableAccount(s, account, fmt.Sprintf("Too many consecutive errors (%d)", account.ConsecutiveErrors))
-			}
-			failCount++
-			continue
-		}
-
-		result, err := CheckAccountWithRetry(account.SSOCookie, userID, "")
-		if err != nil {
-			logger.Log.WithError(err).Errorf("Failed to check account %s for user %s", account.Title, userID)
-
-			account.ConsecutiveErrors++
-			account.LastErrorTime = time.Now()
-			if err := database.DB.Save(&account).Error; err != nil {
-				logger.Log.WithError(err).Error("Failed to update account error count")
-			}
-
-			failCount++
-			continue
-		}
-
-		account.LastCheck = time.Now().Unix()
-		account.ConsecutiveErrors = 0
-		account.LastSuccessfulCheck = time.Now()
-
-		if account.LastStatus != result {
-			HandleStatusChange(s, account, result, &userSettings)
-		} else {
-			if err := database.DB.Save(&account).Error; err != nil {
-				logger.Log.WithError(err).Error("Failed to update account check time")
-			}
-		}
-
-		successCount++
+	metadata := map[string]interface{}{
+		"account_id":       accountID,
+		"success":          success,
+		"response_time_ms": responseTimeMs,
+		"captcha_provider": captchaProvider,
+		"captcha_cost":     captchaCost,
+		"check_type":       "automatic",
 	}
 
-	return successCount, failCount
+	if errorDetails != "" {
+		metadata["error_details"] = errorDetails
+	}
+
+	eventStatus := string(status)
+	if !success {
+		eventStatus = "error"
+	}
+
+	LogAnalyticsEvent("account_check", userID, "", "", eventStatus,
+		shardMgr.ShardID, shardMgr.InstanceID, metadata)
+}
+
+func LogAccountStatusCheck(accountID uint, userID string, status models.Status, checkType, errorDetails string) {
+	shardMgr := GetAppShardManager()
+
+	metadata := map[string]interface{}{
+		"account_id": accountID,
+		"check_type": checkType,
+		"status":     string(status),
+	}
+
+	if errorDetails != "" {
+		metadata["error_details"] = errorDetails
+	}
+
+	LogAnalyticsEvent("account_status_check", userID, "", "", string(status),
+		shardMgr.ShardID, shardMgr.InstanceID, metadata)
+}
+
+func LogNotification(userID string, accountID uint, notificationType string, success bool) {
+	shardMgr := GetAppShardManager()
+
+	metadata := map[string]interface{}{
+		"account_id":        accountID,
+		"notification_type": notificationType,
+		"success":           success,
+		"delivery_method":   "discord",
+	}
+
+	eventStatus := "delivered"
+	if !success {
+		eventStatus = "failed"
+	}
+
+	LogAnalyticsEvent("notification", userID, "", "", eventStatus,
+		shardMgr.ShardID, shardMgr.InstanceID, metadata)
 }
 
 func updateShardStats(instanceID string, processedUsers, successfulChecks, failedChecks int, durationSec float64) error {

--- a/services/shadowban_analytics.go
+++ b/services/shadowban_analytics.go
@@ -1,0 +1,417 @@
+package services
+
+import (
+	"time"
+
+	"github.com/bradselph/CODStatusBot/database"
+	"github.com/bradselph/CODStatusBot/logger"
+	"github.com/bradselph/CODStatusBot/models"
+)
+
+type ShadowbanPeriod struct {
+	AccountID     uint       `json:"account_id"`
+	UserID        string     `json:"user_id"`
+	AccountTitle  string     `json:"account_title"`
+	StartTime     time.Time  `json:"start_time"`
+	EndTime       *time.Time `json:"end_time,omitempty"`
+	DurationHours *float64   `json:"duration_hours,omitempty"`
+	IsCompleted   bool       `json:"is_completed"`
+	StartBanID    uint       `json:"start_ban_id"`
+	EndBanID      *uint      `json:"end_ban_id,omitempty"`
+	CreatedAt     time.Time  `json:"created_at"`
+	UpdatedAt     time.Time  `json:"updated_at"`
+}
+
+func TrackShadowbanTransition(accountID uint, userID string, previousStatus, newStatus models.Status, banID uint) error {
+	logger.Log.Debugf("Tracking shadowban transition for account %d: %s -> %s", accountID, previousStatus, newStatus)
+
+	if (previousStatus == models.StatusGood) &&
+		(newStatus == models.StatusShadowban || newStatus == models.StatusRankLocked) {
+		return startShadowbanPeriod(accountID, userID, banID)
+	}
+
+	if (previousStatus == models.StatusShadowban || previousStatus == models.StatusRankLocked) &&
+		(newStatus == models.StatusGood) {
+		return endShadowbanPeriod(accountID, userID, banID)
+	}
+
+	if previousStatus == models.StatusUnknown && newStatus == models.StatusGood {
+		return logShadowbanRecovery(accountID, userID, banID)
+	}
+
+	if previousStatus == models.StatusUnknown &&
+		(newStatus == models.StatusShadowban || newStatus == models.StatusRankLocked) {
+		return startShadowbanPeriod(accountID, userID, banID)
+	}
+
+	return nil
+}
+
+func startShadowbanPeriod(accountID uint, userID string, banID uint) error {
+	var existingPeriod ShadowbanPeriod
+	result := database.DB.Table("shadowban_periods").
+		Where("account_id = ? AND is_completed = ?", accountID, false).
+		First(&existingPeriod)
+
+	if result.Error == nil {
+		logger.Log.Warnf("Account %d already has an active shadowban period, completing the previous one", accountID)
+		if err := forceCompleteShadowbanPeriod(accountID); err != nil {
+			logger.Log.WithError(err).Error("Failed to complete previous shadowban period")
+		}
+	}
+
+	var account models.Account
+	if err := database.DB.First(&account, accountID).Error; err != nil {
+		logger.Log.WithError(err).Error("Failed to get account info for shadowban tracking")
+		return err
+	}
+
+	period := ShadowbanPeriod{
+		AccountID:    accountID,
+		UserID:       userID,
+		AccountTitle: account.Title,
+		StartTime:    time.Now(),
+		IsCompleted:  false,
+		StartBanID:   banID,
+		CreatedAt:    time.Now(),
+		UpdatedAt:    time.Now(),
+	}
+
+	if err := database.DB.Table("shadowban_periods").Create(&period).Error; err != nil {
+		logger.Log.WithError(err).Error("Failed to create shadowban period record")
+		return err
+	}
+
+	logger.Log.Infof("Started tracking shadowban period for account %s (ID: %d)", account.Title, accountID)
+
+	shardMgr := GetAppShardManager()
+	LogAnalyticsEvent("shadowban_started", userID, "", "", "shadowban_tracking",
+		shardMgr.ShardID, shardMgr.InstanceID, map[string]interface{}{
+			"account_id":    accountID,
+			"account_title": account.Title,
+			"start_ban_id":  banID,
+		})
+
+	return nil
+}
+
+func endShadowbanPeriod(accountID uint, userID string, banID uint) error {
+	var period ShadowbanPeriod
+	result := database.DB.Table("shadowban_periods").
+		Where("account_id = ? AND is_completed = ?", accountID, false).
+		First(&period)
+
+	if result.Error != nil {
+		logger.Log.Warnf("No active shadowban period found for account %d when trying to end it", accountID)
+		return logShadowbanRecovery(accountID, userID, banID)
+	}
+
+	now := time.Now()
+	duration := now.Sub(period.StartTime)
+	durationHours := duration.Hours()
+
+	period.EndTime = &now
+	period.DurationHours = &durationHours
+	period.IsCompleted = true
+	period.EndBanID = &banID
+	period.UpdatedAt = now
+
+	if err := database.DB.Table("shadowban_periods").Save(&period).Error; err != nil {
+		logger.Log.WithError(err).Error("Failed to complete shadowban period")
+		return err
+	}
+
+	logger.Log.Infof("Completed shadowban period for account %s (ID: %d): %.2f hours (%.1f days)",
+		period.AccountTitle, accountID, durationHours, durationHours/24)
+
+	shardMgr := GetAppShardManager()
+	LogAnalyticsEvent("shadowban_ended", userID, "", "", "shadowban_tracking",
+		shardMgr.ShardID, shardMgr.InstanceID, map[string]interface{}{
+			"account_id":     accountID,
+			"account_title":  period.AccountTitle,
+			"duration_hours": durationHours,
+			"duration_days":  durationHours / 24,
+			"start_ban_id":   period.StartBanID,
+			"end_ban_id":     banID,
+		})
+
+	return nil
+}
+
+func logShadowbanRecovery(accountID uint, userID string, banID uint) error {
+	var account models.Account
+	if err := database.DB.First(&account, accountID).Error; err != nil {
+		logger.Log.WithError(err).Error("Failed to get account info for shadowban recovery logging")
+		return err
+	}
+
+	logger.Log.Infof("Account %s (ID: %d) recovered from shadowban/unknown state (no reliable duration data)",
+		account.Title, accountID)
+
+	shardMgr := GetAppShardManager()
+	LogAnalyticsEvent("shadowban_recovery", userID, "", "", "shadowban_tracking",
+		shardMgr.ShardID, shardMgr.InstanceID, map[string]interface{}{
+			"account_id":      accountID,
+			"account_title":   account.Title,
+			"recovery_ban_id": banID,
+			"note":            "No reliable start time available",
+		})
+
+	return nil
+}
+
+func forceCompleteShadowbanPeriod(accountID uint) error {
+	now := time.Now()
+
+	result := database.DB.Table("shadowban_periods").
+		Where("account_id = ? AND is_completed = ?", accountID, false).
+		Updates(map[string]interface{}{
+			"is_completed": true,
+			"updated_at":   now,
+			"end_time":     now,
+		})
+
+	if result.Error != nil {
+		return result.Error
+	}
+
+	if result.RowsAffected > 0 {
+		logger.Log.Infof("Force completed %d hanging shadowban periods for account %d", result.RowsAffected, accountID)
+	}
+
+	return nil
+}
+
+func GetShadowbanStatistics(userID string, accountID *uint, days int) (map[string]interface{}, error) {
+	if days <= 0 {
+		days = 30
+	}
+
+	startDate := time.Now().AddDate(0, 0, -days)
+	stats := map[string]interface{}{
+		"period_days": days,
+		"start_date":  startDate.Format("2006-01-02"),
+		"end_date":    time.Now().Format("2006-01-02"),
+		"user_id":     userID,
+	}
+
+	query := database.DB.Table("shadowban_periods").Where("user_id = ? AND created_at >= ?", userID, startDate)
+	if accountID != nil {
+		query = query.Where("account_id = ?", *accountID)
+		stats["account_id"] = *accountID
+	}
+
+	var completedPeriods []ShadowbanPeriod
+	if err := query.Where("is_completed = ?", true).Find(&completedPeriods).Error; err != nil {
+		return stats, err
+	}
+
+	stats["total_completed_periods"] = len(completedPeriods)
+
+	var activePeriods int64
+	if err := query.Where("is_completed = ?", false).Count(&activePeriods).Error; err != nil {
+		return stats, err
+	}
+	stats["active_periods"] = activePeriods
+
+	if len(completedPeriods) > 0 {
+		var totalHours float64
+		var minHours, maxHours float64
+		durations := make([]float64, 0, len(completedPeriods))
+
+		for i, period := range completedPeriods {
+			if period.DurationHours != nil {
+				hours := *period.DurationHours
+				totalHours += hours
+				durations = append(durations, hours)
+
+				if i == 0 {
+					minHours = hours
+					maxHours = hours
+				} else {
+					if hours < minHours {
+						minHours = hours
+					}
+					if hours > maxHours {
+						maxHours = hours
+					}
+				}
+			}
+		}
+
+		if len(durations) > 0 {
+			avgHours := totalHours / float64(len(durations))
+			stats["average_duration_hours"] = avgHours
+			stats["average_duration_days"] = avgHours / 24
+			stats["min_duration_hours"] = minHours
+			stats["max_duration_hours"] = maxHours
+			stats["min_duration_days"] = minHours / 24
+			stats["max_duration_days"] = maxHours / 24
+			stats["total_shadowban_hours"] = totalHours
+			stats["total_shadowban_days"] = totalHours / 24
+		}
+
+		var recentPeriods []map[string]interface{}
+		for _, period := range completedPeriods {
+			periodInfo := map[string]interface{}{
+				"account_title": period.AccountTitle,
+				"start_time":    period.StartTime.Format("2006-01-02 15:04:05"),
+				"end_time":      period.EndTime.Format("2006-01-02 15:04:05"),
+			}
+			if period.DurationHours != nil {
+				periodInfo["duration_hours"] = *period.DurationHours
+				periodInfo["duration_days"] = *period.DurationHours / 24
+			}
+			recentPeriods = append(recentPeriods, periodInfo)
+		}
+		stats["recent_periods"] = recentPeriods
+	}
+
+	return stats, nil
+}
+
+func GetGlobalShadowbanStats(days int) (map[string]interface{}, error) {
+	if days <= 0 {
+		days = 30
+	}
+
+	startDate := time.Now().AddDate(0, 0, -days)
+	stats := map[string]interface{}{
+		"period_days": days,
+		"start_date":  startDate.Format("2006-01-02"),
+		"end_date":    time.Now().Format("2006-01-02"),
+	}
+
+	var totalPeriods int64
+	if err := database.DB.Table("shadowban_periods").
+		Where("created_at >= ?", startDate).Count(&totalPeriods).Error; err != nil {
+		return stats, err
+	}
+	stats["total_periods"] = totalPeriods
+
+	var completedPeriods []ShadowbanPeriod
+	if err := database.DB.Table("shadowban_periods").
+		Where("created_at >= ? AND is_completed = ? AND duration_hours IS NOT NULL", startDate, true).
+		Find(&completedPeriods).Error; err != nil {
+		return stats, err
+	}
+	stats["completed_periods"] = len(completedPeriods)
+
+	var activePeriods int64
+	if err := database.DB.Table("shadowban_periods").
+		Where("created_at >= ? AND is_completed = ?", startDate, false).
+		Count(&activePeriods).Error; err != nil {
+		return stats, err
+	}
+	stats["active_periods"] = activePeriods
+
+	if len(completedPeriods) > 0 {
+		var totalHours float64
+		durationRanges := map[string]int{
+			"under_24h":    0,
+			"1_3_days":     0,
+			"3_7_days":     0,
+			"7_14_days":    0,
+			"over_14_days": 0,
+		}
+
+		for _, period := range completedPeriods {
+			if period.DurationHours != nil {
+				hours := *period.DurationHours
+				totalHours += hours
+
+				days := hours / 24
+				switch {
+				case days < 1:
+					durationRanges["under_24h"]++
+				case days <= 3:
+					durationRanges["1_3_days"]++
+				case days <= 7:
+					durationRanges["3_7_days"]++
+				case days <= 14:
+					durationRanges["7_14_days"]++
+				default:
+					durationRanges["over_14_days"]++
+				}
+			}
+		}
+
+		avgHours := totalHours / float64(len(completedPeriods))
+		stats["average_duration_hours"] = avgHours
+		stats["average_duration_days"] = avgHours / 24
+		stats["duration_distribution"] = durationRanges
+	}
+
+	var uniqueUsers int64
+	if err := database.DB.Table("shadowban_periods").
+		Where("created_at >= ?", startDate).
+		Distinct("user_id").Count(&uniqueUsers).Error; err != nil {
+		return stats, err
+	}
+	stats["unique_users_affected"] = uniqueUsers
+
+	return stats, nil
+}
+
+func CleanupOldShadowbanPeriods(retentionDays int) error {
+	if retentionDays <= 0 {
+		logger.Log.Warn("Invalid retention days for shadowban period cleanup, skipping")
+		return nil
+	}
+
+	cutoffDate := time.Now().AddDate(0, 0, -retentionDays)
+
+	var oldRecordsCount int64
+	if err := database.DB.Table("shadowban_periods").
+		Where("created_at < ?", cutoffDate).Count(&oldRecordsCount).Error; err != nil {
+		return err
+	}
+
+	if oldRecordsCount == 0 {
+		logger.Log.Debug("No old shadowban period data to clean up")
+		return nil
+	}
+
+	logger.Log.Infof("Cleaning up %d shadowban period records older than %d days", oldRecordsCount, retentionDays)
+
+	result := database.DB.Table("shadowban_periods").Where("created_at < ?", cutoffDate).Delete(&ShadowbanPeriod{})
+	if result.Error != nil {
+		return result.Error
+	}
+
+	logger.Log.Infof("Successfully cleaned up %d old shadowban period records", result.RowsAffected)
+	return nil
+}
+
+func CreateShadowbanPeriodsTable() error {
+	sql := `
+	CREATE TABLE IF NOT EXISTS shadowban_periods (
+		id BIGINT AUTO_INCREMENT PRIMARY KEY,
+		account_id BIGINT NOT NULL,
+		user_id VARCHAR(255) NOT NULL,
+		account_title VARCHAR(255) NOT NULL,
+		start_time DATETIME(3) NOT NULL,
+		end_time DATETIME(3) NULL,
+		duration_hours DOUBLE NULL,
+		is_completed BOOLEAN NOT NULL DEFAULT FALSE,
+		start_ban_id BIGINT NOT NULL,
+		end_ban_id BIGINT NULL,
+		created_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+		updated_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
+		INDEX idx_account_id (account_id),
+		INDEX idx_user_id (user_id),
+		INDEX idx_created_at (created_at),
+		INDEX idx_is_completed (is_completed),
+		INDEX idx_start_time (start_time),
+		INDEX idx_end_time (end_time),
+		FOREIGN KEY (account_id) REFERENCES accounts(id) ON DELETE CASCADE
+	) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci`
+
+	if err := database.DB.Exec(sql).Error; err != nil {
+		logger.Log.WithError(err).Error("Failed to create shadowban_periods table")
+		return err
+	}
+
+	logger.Log.Info("Successfully created or verified shadowban_periods table")
+	return nil
+}

--- a/services/shard_health.go
+++ b/services/shard_health.go
@@ -1,0 +1,268 @@
+package services
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/bradselph/CODStatusBot/database"
+	"github.com/bradselph/CODStatusBot/logger"
+	"github.com/bradselph/CODStatusBot/models"
+)
+
+func ShardHealthCheck() (*ShardHealthReport, error) {
+	report := &ShardHealthReport{
+		CheckTime: time.Now(),
+		Healthy:   true,
+		Issues:    []string{},
+		Warnings:  []string{},
+	}
+
+	shardMgr := GetAppShardManager()
+	if !shardMgr.Initialized {
+		report.Healthy = false
+		report.Issues = append(report.Issues, "Shard manager not initialized")
+		return report, nil
+	}
+
+	report.CurrentShard = shardMgr.ShardID
+	report.TotalShards = shardMgr.TotalShards
+	report.InstanceID = shardMgr.InstanceID
+	report.IsLeader = shardMgr.IsLeader()
+
+	var activeShards []models.ShardInfo
+	if err := database.DB.Where("status = 'active'").Find(&activeShards).Error; err != nil {
+		report.Healthy = false
+		report.Issues = append(report.Issues, fmt.Sprintf("Failed to query active shards: %v", err))
+		return report, err
+	}
+
+	report.ActiveShards = len(activeShards)
+
+	heartbeatTimeout := 90 * time.Second
+	var deadShards []models.ShardInfo
+	if err := database.DB.Where("status = 'active' AND last_heartbeat < ?",
+		time.Now().Add(-heartbeatTimeout)).Find(&deadShards).Error; err != nil {
+		report.Warnings = append(report.Warnings, fmt.Sprintf("Failed to check for dead shards: %v", err))
+	} else if len(deadShards) > 0 {
+		report.Warnings = append(report.Warnings, fmt.Sprintf("Found %d potentially dead shards", len(deadShards)))
+		report.DeadShards = len(deadShards)
+	}
+
+	userStats, err := ValidateUserShardAssignments()
+	if err != nil {
+		report.Warnings = append(report.Warnings, fmt.Sprintf("Failed to validate user assignments: %v", err))
+	} else {
+		report.UserDistribution = userStats
+
+		if distribution, ok := userStats["shard_distribution"].(map[int]int); ok {
+			maxUsers := 0
+			minUsers := int(^uint(0) >> 1)
+
+			for _, count := range distribution {
+				if count > maxUsers {
+					maxUsers = count
+				}
+				if count < minUsers {
+					minUsers = count
+				}
+			}
+
+			if maxUsers > 0 && minUsers >= 0 {
+				ratio := float64(maxUsers) / float64(minUsers+1)
+				if ratio > 2.0 {
+					report.Warnings = append(report.Warnings,
+						fmt.Sprintf("Uneven user distribution detected (ratio: %.2f)", ratio))
+				}
+			}
+		}
+	}
+
+	var totalAccounts int64
+	if err := database.DB.Model(&models.Account{}).Count(&totalAccounts).Error; err != nil {
+		report.Warnings = append(report.Warnings, fmt.Sprintf("Failed to count total accounts: %v", err))
+	} else {
+		report.TotalAccounts = int(totalAccounts)
+
+		var accounts []models.Account
+		if err := database.DB.Find(&accounts).Error; err != nil {
+			report.Warnings = append(report.Warnings, fmt.Sprintf("Failed to fetch accounts: %v", err))
+		} else {
+			filteredAccounts := FilterAccountsByShardAssignment(accounts)
+			report.ShardAccounts = len(filteredAccounts)
+
+			if report.TotalShards > 0 {
+				expectedRatio := float64(report.ShardAccounts) / float64(report.TotalAccounts)
+				idealRatio := 1.0 / float64(report.TotalShards)
+
+				if expectedRatio < idealRatio*0.5 || expectedRatio > idealRatio*2.0 {
+					report.Warnings = append(report.Warnings,
+						fmt.Sprintf("Account distribution deviation: %.2f%% vs expected %.2f%%",
+							expectedRatio*100, idealRatio*100))
+				}
+			}
+		}
+	}
+
+	if time.Since(shardMgr.HeartbeatTime) > 2*time.Minute {
+		report.Warnings = append(report.Warnings, "Heartbeat is stale")
+	}
+
+	if shardMgr.rebalancing {
+		report.Warnings = append(report.Warnings, "Shard rebalancing in progress")
+	}
+
+	if len(report.Issues) > 0 {
+		report.Healthy = false
+	} else if len(report.Warnings) > 3 {
+		report.Healthy = false
+		report.Issues = append(report.Issues, "Too many warnings detected")
+	}
+
+	return report, nil
+}
+
+type ShardHealthReport struct {
+	CheckTime        time.Time              `json:"check_time"`
+	Healthy          bool                   `json:"healthy"`
+	Issues           []string               `json:"issues"`
+	Warnings         []string               `json:"warnings"`
+	CurrentShard     int                    `json:"current_shard"`
+	TotalShards      int                    `json:"total_shards"`
+	ActiveShards     int                    `json:"active_shards"`
+	DeadShards       int                    `json:"dead_shards"`
+	InstanceID       string                 `json:"instance_id"`
+	IsLeader         bool                   `json:"is_leader"`
+	TotalAccounts    int                    `json:"total_accounts"`
+	ShardAccounts    int                    `json:"shard_accounts"`
+	UserDistribution map[string]interface{} `json:"user_distribution"`
+}
+
+func (r *ShardHealthReport) String() string {
+	status := "HEALTHY"
+	if !r.Healthy {
+		status = "UNHEALTHY"
+	}
+
+	summary := fmt.Sprintf("Shard Health Report [%s]\n", status)
+	summary += fmt.Sprintf("Time: %s\n", r.CheckTime.Format("2006-01-02 15:04:05"))
+	summary += fmt.Sprintf("Shard: %d/%d (Instance: %s)\n", r.CurrentShard, r.TotalShards, r.InstanceID)
+	summary += fmt.Sprintf("Active Shards: %d, Dead Shards: %d\n", r.ActiveShards, r.DeadShards)
+	summary += fmt.Sprintf("Accounts: %d/%d assigned to this shard\n", r.ShardAccounts, r.TotalAccounts)
+	summary += fmt.Sprintf("Leader: %v\n", r.IsLeader)
+
+	if len(r.Issues) > 0 {
+		summary += "\nISSUES:\n"
+		for _, issue := range r.Issues {
+			summary += fmt.Sprintf("  - %s\n", issue)
+		}
+	}
+
+	if len(r.Warnings) > 0 {
+		summary += "\nWARNINGS:\n"
+		for _, warning := range r.Warnings {
+			summary += fmt.Sprintf("  - %s\n", warning)
+		}
+	}
+
+	return summary
+}
+
+func PerformShardHealthCheck() {
+	report, err := ShardHealthCheck()
+	if err != nil {
+		logger.Log.WithError(err).Error("Failed to perform shard health check")
+		return
+	}
+
+	if report.Healthy {
+		logger.Log.Info("Shard health check passed")
+		logger.Log.Debugf("Health Report:\n%s", report.String())
+	} else {
+		logger.Log.Warn("Shard health check failed")
+		logger.Log.Warnf("Health Report:\n%s", report.String())
+	}
+
+	shardMgr := GetAppShardManager()
+	metadata := map[string]interface{}{
+		"healthy":        report.Healthy,
+		"issues_count":   len(report.Issues),
+		"warnings_count": len(report.Warnings),
+		"active_shards":  report.ActiveShards,
+		"dead_shards":    report.DeadShards,
+		"total_accounts": report.TotalAccounts,
+		"shard_accounts": report.ShardAccounts,
+	}
+
+	status := "healthy"
+	if !report.Healthy {
+		status = "unhealthy"
+	}
+
+	LogAnalyticsEvent("shard_health_check", "", "", "", status,
+		shardMgr.ShardID, shardMgr.InstanceID, metadata)
+}
+
+func GetShardDistributionStats() (map[string]interface{}, error) {
+	stats := make(map[string]interface{})
+
+	var activeShards []models.ShardInfo
+	if err := database.DB.Where("status = 'active'").Find(&activeShards).Error; err != nil {
+		return stats, err
+	}
+
+	stats["active_shards"] = len(activeShards)
+	stats["shard_details"] = activeShards
+
+	userStats, err := ValidateUserShardAssignments()
+	if err != nil {
+		return stats, err
+	}
+	stats["user_distribution"] = userStats
+
+	var allAccounts []models.Account
+	if err := database.DB.Select("user_id").Find(&allAccounts).Error; err != nil {
+		return stats, err
+	}
+
+	accountDistribution := make(map[int]int)
+	totalShards := len(activeShards)
+	if totalShards == 0 {
+		totalShards = 1
+	}
+
+	for _, account := range allAccounts {
+		if account.UserID == "" {
+			continue
+		}
+		shard := getUserShard(account.UserID, totalShards)
+		accountDistribution[shard]++
+	}
+
+	stats["account_distribution"] = accountDistribution
+	stats["total_accounts"] = len(allAccounts)
+
+	return stats, nil
+}
+
+func FixShardAssignments() error {
+	shardMgr := GetAppShardManager()
+	if !shardMgr.IsLeader() {
+		return fmt.Errorf("only leader shard can fix assignments")
+	}
+
+	logger.Log.Info("Starting shard assignment fixes")
+
+	shardMgr.performMaintenance()
+
+	CleanupUsersByShardAssignment()
+	CleanupOldShardInfo()
+
+	stats, err := ValidateUserShardAssignments()
+	if err != nil {
+		return fmt.Errorf("failed to validate assignments after fix: %w", err)
+	}
+
+	logger.Log.Infof("Shard assignment fixes completed. Stats: %+v", stats)
+
+	return nil
+}

--- a/services/shard_manager.go
+++ b/services/shard_manager.go
@@ -10,7 +10,6 @@ import (
 	"github.com/bwmarrin/discordgo"
 )
 
-// ShardManager handles the creation and management of Discord gateway shards
 type ShardManager struct {
 	sync.Mutex
 	Sessions       []*discordgo.Session
@@ -19,11 +18,9 @@ type ShardManager struct {
 	StartedShards  int
 }
 
-// NewShardManager creates a new shard manager
 func NewShardManager() (*ShardManager, error) {
 	cfg := configuration.Get()
 
-	// Get gateway info to determine shard count
 	gatewayInfo, err := GetGatewayBotInfo(cfg.Discord.Token)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get gateway bot info: %w", err)
@@ -40,7 +37,6 @@ func NewShardManager() (*ShardManager, error) {
 	}, nil
 }
 
-// GetGatewayBotInfo retrieves the gateway bot info from Discord
 func GetGatewayBotInfo(token string) (*discordgo.GatewayBotResponse, error) {
 	s, err := discordgo.New("Bot " + token)
 	if err != nil {
@@ -50,42 +46,33 @@ func GetGatewayBotInfo(token string) (*discordgo.GatewayBotResponse, error) {
 	return s.GatewayBot()
 }
 
-// StartShards initializes and connects all shards
 func (sm *ShardManager) StartShards(token string, handlers map[string]func(*discordgo.Session, *discordgo.InteractionCreate)) error {
 	sm.Lock()
 	defer sm.Unlock()
 
-	// Track which rate limit buckets we've opened
 	buckets := make(map[int]bool)
 
 	for i := 0; i < sm.TotalShards; i++ {
-		// Calculate the rate limit bucket for this shard
 		bucket := i % sm.MaxConcurrency
 
-		// If this is a new bucket, we need to wait for all shards in the previous bucket to start
 		if i >= sm.MaxConcurrency && !buckets[bucket] {
 			logger.Log.Infof("Waiting for previous bucket to complete before starting shard %d (bucket %d)", i, bucket)
-			time.Sleep(5 * time.Second) // Discord rate limiting between buckets
+			time.Sleep(5 * time.Second)
 		}
 
-		// Mark this bucket as opened
 		buckets[bucket] = true
 
-		// Create and start the shard
 		logger.Log.Infof("Starting shard %d of %d", i, sm.TotalShards)
 		session, err := discordgo.New("Bot " + token)
 		if err != nil {
 			return fmt.Errorf("error creating session for shard %d: %w", i, err)
 		}
 
-		// Set the shard ID
 		session.ShardID = i
 		session.ShardCount = sm.TotalShards
 
-		// Register handlers
 		registerHandlers(session, handlers)
 
-		// Open connection to Discord
 		err = session.Open()
 		if err != nil {
 			return fmt.Errorf("error opening session for shard %d: %w", i, err)
@@ -96,7 +83,6 @@ func (sm *ShardManager) StartShards(token string, handlers map[string]func(*disc
 
 		logger.Log.Infof("Shard %d started successfully", i)
 
-		// Wait between shards in the same bucket to avoid hitting rate limits
 		if sm.MaxConcurrency > 1 {
 			time.Sleep(1 * time.Second)
 		}
@@ -106,7 +92,6 @@ func (sm *ShardManager) StartShards(token string, handlers map[string]func(*disc
 	return nil
 }
 
-// Close closes all shard connections
 func (sm *ShardManager) Close() {
 	sm.Lock()
 	defer sm.Unlock()
@@ -119,24 +104,20 @@ func (sm *ShardManager) Close() {
 	}
 }
 
-// GetSession returns the session for a specific guild
 func (sm *ShardManager) GetSession(guildID string) *discordgo.Session {
 	if len(sm.Sessions) == 1 {
 		return sm.Sessions[0]
 	}
 
-	// Calculate which shard this guild belongs to
 	shardID := getShardIDForGuild(guildID, sm.TotalShards)
 
 	if shardID >= 0 && shardID < len(sm.Sessions) {
 		return sm.Sessions[shardID]
 	}
 
-	// Default to first shard (for DMs and other non-guild interactions)
 	return sm.Sessions[0]
 }
 
-// registerHandlers registers command handlers for a session
 func registerHandlers(s *discordgo.Session, handlers map[string]func(*discordgo.Session, *discordgo.InteractionCreate)) {
 	s.AddHandler(func(s *discordgo.Session, i *discordgo.InteractionCreate) {
 		switch i.Type {
@@ -156,17 +137,13 @@ func registerHandlers(s *discordgo.Session, handlers map[string]func(*discordgo.
 	})
 }
 
-// getShardIDForGuild calculates the shard ID for a guild using Discord's sharding formula
 func getShardIDForGuild(guildID string, shardCount int) int {
-	// If no guild ID (e.g., for DMs), return shard 0
 	if guildID == "" {
 		return 0
 	}
 
-	// Parse guild ID to uint64
 	var id uint64
 	fmt.Sscanf(guildID, "%d", &id)
 
-	// Use Discord's sharding formula: (guild_id >> 22) % num_shards
 	return int((id >> 22) % uint64(shardCount))
 }

--- a/services/ssocookie.go
+++ b/services/ssocookie.go
@@ -11,6 +11,30 @@ import (
 	"github.com/bradselph/CODStatusBot/logger"
 )
 
+/*
+	func FormatDuration(duration time.Duration) string {
+		if duration <= 0 {
+			return "Expired"
+		}
+
+		if duration < 2*time.Hour {
+			minutes := int(duration.Minutes())
+			if minutes <= 0 {
+				return "Less than 1 minute"
+			}
+			return fmt.Sprintf("%d minutes", minutes)
+		}
+
+		days := int(duration.Hours() / 24)
+		hours := int(duration.Hours()) % 24
+
+		if days > 0 {
+			return fmt.Sprintf("%d days, %d hours", days, hours)
+		} else {
+			return fmt.Sprintf("%d hours", hours)
+		}
+	}
+*/
 func DecodeSSOCookie(encodedStr string) (int64, error) {
 	encodedStr = strings.TrimSpace(encodedStr)
 	padding := len(encodedStr) % 4
@@ -56,7 +80,7 @@ func CheckSSOCookieExpiration(expirationTimestamp int64) (time.Duration, error) 
 		return 0, fmt.Errorf("cookie has expired")
 	}
 
-	maxDuration := 14 * 24 * time.Hour // 14 days
+	maxDuration := 14 * 24 * time.Hour
 	if timeUntilExpiration > maxDuration {
 		return maxDuration, nil
 	}
@@ -73,7 +97,15 @@ func FormatExpirationTime(expirationTimestamp int64) string {
 		return "Expired"
 	}
 
-	maxDuration := 14 * 24 * time.Hour // 14 days
+	if timeUntilExpiration < 2*time.Hour {
+		minutes := int(timeUntilExpiration.Minutes())
+		if minutes <= 0 {
+			return "Less than 1 minute"
+		}
+		return fmt.Sprintf("%d minutes", minutes)
+	}
+
+	maxDuration := 14 * 24 * time.Hour
 	if timeUntilExpiration > maxDuration {
 		timeUntilExpiration = maxDuration
 	}

--- a/services/user_settings.go
+++ b/services/user_settings.go
@@ -75,8 +75,18 @@ func initDefaultSettings() {
 }
 
 func GetUserSettings(userID string) (models.UserSettings, error) {
+	if userID == "" {
+		return models.UserSettings{}, fmt.Errorf("empty userID provided")
+	}
+
+	shardMgr := GetAppShardManager()
+	if shardMgr.Initialized && !shardMgr.IsUserAssignedToShard(userID) {
+		assignedShard := shardMgr.GetUserShardID(userID)
+		return models.UserSettings{}, fmt.Errorf("user %s assigned to shard %d, current shard is %d", userID, assignedShard, shardMgr.ShardID)
+	}
+
 	cfg := configuration.Get()
-	logger.Log.Infof("Getting user settings for user: %s", userID)
+	logger.Log.Debugf("Getting user settings for user: %s (shard %d)", userID, shardMgr.ShardID)
 
 	var settings models.UserSettings
 	result := database.DB.Where(models.UserSettings{UserID: userID}).FirstOrCreate(&settings)
@@ -170,6 +180,16 @@ func GetUserSettings(userID string) (models.UserSettings, error) {
 }
 
 func GetUserCaptchaKey(userID string) (string, float64, error) {
+	if userID == "" {
+		return "", 0, fmt.Errorf("empty userID provided")
+	}
+
+	shardMgr := GetAppShardManager()
+	if shardMgr.Initialized && !shardMgr.IsUserAssignedToShard(userID) {
+		assignedShard := shardMgr.GetUserShardID(userID)
+		return "", 0, fmt.Errorf("user %s assigned to shard %d, current shard is %d", userID, assignedShard, shardMgr.ShardID)
+	}
+
 	var settings models.UserSettings
 	result := database.DB.Where(models.UserSettings{UserID: userID}).First(&settings)
 	if result.Error != nil {
@@ -299,6 +319,16 @@ func GetUserCaptchaKey(userID string) (string, float64, error) {
 }
 
 func GetCaptchaSolver(userID string) (CaptchaSolver, error) {
+	if userID == "" {
+		return nil, fmt.Errorf("empty userID provided")
+	}
+
+	shardMgr := GetAppShardManager()
+	if shardMgr.Initialized && !shardMgr.IsUserAssignedToShard(userID) {
+		assignedShard := shardMgr.GetUserShardID(userID)
+		return nil, fmt.Errorf("user %s assigned to shard %d, current shard is %d", userID, assignedShard, shardMgr.ShardID)
+	}
+
 	settings, err := GetUserSettings(userID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get user settings: %w", err)
@@ -320,6 +350,16 @@ func GetDefaultSettings() (models.UserSettings, error) {
 }
 
 func RemoveCaptchaKey(userID string) error {
+	if userID == "" {
+		return fmt.Errorf("empty userID provided")
+	}
+
+	shardMgr := GetAppShardManager()
+	if shardMgr.Initialized && !shardMgr.IsUserAssignedToShard(userID) {
+		assignedShard := shardMgr.GetUserShardID(userID)
+		return fmt.Errorf("user %s assigned to shard %d, current shard is %d", userID, assignedShard, shardMgr.ShardID)
+	}
+
 	var settings models.UserSettings
 	result := database.DB.Where("user_id = ?", userID).First(&settings)
 	if result.Error != nil {

--- a/utils/validation.go
+++ b/utils/validation.go
@@ -98,11 +98,10 @@ func ValidateCheckInterval(interval int) error {
 		return ValidationError{"check_interval", "Check interval must be at least 1 minute"}
 	}
 
-	if interval > 1440 { // 24 hours
+	if interval > 1440 {
 		return ValidationError{"check_interval", "Check interval cannot be longer than 24 hours (1440 minutes)"}
 	}
 
-	// For users without custom API keys, enforce minimum interval
 	if interval < cfg.Intervals.Check {
 		return ValidationError{"check_interval", fmt.Sprintf("Check interval must be at least %d minutes for default users", cfg.Intervals.Check)}
 	}
@@ -115,7 +114,7 @@ func ValidateNotificationInterval(interval float64) error {
 		return ValidationError{"notification_interval", "Notification interval must be at least 0.5 hours"}
 	}
 
-	if interval > 168 { // 7 days
+	if interval > 168 {
 		return ValidationError{"notification_interval", "Notification interval cannot be longer than 7 days (168 hours)"}
 	}
 


### PR DESCRIPTION
Adds application-level sharding to distribute workload and enable horizontal scaling across multiple bot instances.

This change introduces a database-backed sharding mechanism where instances register themselves, perform heartbeats, elect a leader, and rebalance shard assignments dynamically based on active instances.

Key changes include:

- Implement database schema and logic for tracking shard instances.
- Assign users and guilds to specific shards using consistent hashing.
- Filter Discord interactions and messages to be processed only by the assigned shard, preventing duplicate processing.
- Distribute periodic tasks (account checks) across all active shards.
- Designate critical background tasks (cleanup routines, daily updates) and the Admin API to run exclusively on the leader shard to avoid conflicts and ensure coordination.
- Enhance logging and analytics events to include shard and instance identifiers for better monitoring and debugging in a sharded setup.
- Add graceful shutdown logic to mark shards as inactive in the database.

This implementation allows for improved scalability, reliability, and workload management as the user base and number of accounts grow.