### PR TITLE
fix(command): Correct import path for shadowbanstats command

### DIFF
--- a/command/setupcommand.go
+++ b/command/setupcommand.go
@@ -19,7 +19,7 @@ import (
 	"github.com/bradselph/CODStatusBot/command/setcheckinterval"
 	"github.com/bradselph/CODStatusBot/command/setephemeral"
 	"github.com/bradselph/CODStatusBot/command/setnotifications"
-	"github.com/bradselph/CODStatusBot/command/shadowbansta
+	"github.com/bradselph/CODStatusBot/command/shadowbanstats"
 	"github.com/bradselph/CODStatusBot/command/togglecheck"
 	"github.com/bradselph/CODStatusBot/command/updateaccount"
 	"github.com/bradselph/CODStatusBot/command/verdansk"


### PR DESCRIPTION
Corrects a typo in the import path for the shadowbanstats command within the setupcommand.go file.

The previous import path contained a typo (`shadowbansta`), which prevented the shadowbanstats command package from being correctly imported.

This change ensures the shadowbanstats command is properly imported and available for registration and use within the application's command setup process.